### PR TITLE
Support virtual infrared remote devices

### DIFF
--- a/device.go
+++ b/device.go
@@ -11,8 +11,8 @@ type GetDevicesResponse struct {
 }
 
 type GetDevicesResponseBody struct {
-	DeviceList         []interface{}          `json:"deviceList"`
-	InfraredRemoteList []InfraredRemoteDevice `json:"infraredRemoteList"`
+	DeviceList         []interface{} `json:"deviceList"`
+	InfraredRemoteList []interface{} `json:"infraredRemoteList"`
 }
 
 type CommonDevice struct {
@@ -79,6 +79,62 @@ type InfraredRemoteDevice struct {
 	DeviceName  string `json:"deviceName"`
 	RemoteType  string `json:"remoteType"`
 	HubDeviceId string `json:"hubDeviceId"`
+}
+
+type InfraredRemoteAirConditionerDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteTVDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteLightDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteStreamerDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteSetTopBoxDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteDvdPlayerDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteFanDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteProjectorDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteCameraDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteAirPurifierDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteSpeakerDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteWaterHeaterDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteRobotVacuumCleanerDevice struct {
+	InfraredRemoteDevice
+}
+
+type InfraredRemoteOthersDevice struct {
+	InfraredRemoteDevice
 }
 
 func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
@@ -148,9 +204,78 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 		response.Body.DeviceList = parsedDevices
 
 		// Set the Client for each InfraredRemoteDevice
-		for _, infraredRemoteDevice := range response.Body.InfraredRemoteList {
-			infraredRemoteDevice.Client = client
+		var parsedInfraredRemoteDevices []interface{}
+		for _, infraredRemoteDeviceInterface := range response.Body.InfraredRemoteList {
+			infraredRemoteDevice, ok := infraredRemoteDeviceInterface.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("failed to cast infraredRemoteDevice to map[string]interface{}")
+			}
+			jsonString, err := json.Marshal(infraredRemoteDevice)
+			if err != nil {
+				return err
+			}
+
+			remoteType, ok := infraredRemoteDevice["remoteType"].(string)
+			if !ok {
+				return fmt.Errorf("failed to cast remoteType to string")
+			}
+
+			var parsedInfrared interface{}
+			switch remoteType {
+			case "Air Conditioner":
+				parsedInfrared = &InfraredRemoteAirConditionerDevice{}
+				parsedInfrared.(*InfraredRemoteAirConditionerDevice).Client = client
+			case "TV":
+				parsedInfrared = &InfraredRemoteTVDevice{}
+				parsedInfrared.(*InfraredRemoteTVDevice).Client = client
+			case "Light":
+				parsedInfrared = &InfraredRemoteLightDevice{}
+				parsedInfrared.(*InfraredRemoteLightDevice).Client = client
+			case "Streamer":
+				parsedInfrared = &InfraredRemoteStreamerDevice{}
+				parsedInfrared.(*InfraredRemoteStreamerDevice).Client = client
+			case "Set Top Box":
+				parsedInfrared = &InfraredRemoteSetTopBoxDevice{}
+				parsedInfrared.(*InfraredRemoteSetTopBoxDevice).Client = client
+			case "DVD Player":
+				parsedInfrared = &InfraredRemoteDvdPlayerDevice{}
+				parsedInfrared.(*InfraredRemoteDvdPlayerDevice).Client = client
+			case "Fan":
+				parsedInfrared = &InfraredRemoteFanDevice{}
+				parsedInfrared.(*InfraredRemoteFanDevice).Client = client
+			case "Projector":
+				parsedInfrared = &InfraredRemoteProjectorDevice{}
+				parsedInfrared.(*InfraredRemoteProjectorDevice).Client = client
+			case "Camera":
+				parsedInfrared = &InfraredRemoteCameraDevice{}
+				parsedInfrared.(*InfraredRemoteCameraDevice).Client = client
+			case "Air Purifier":
+				parsedInfrared = &InfraredRemoteAirPurifierDevice{}
+				parsedInfrared.(*InfraredRemoteAirPurifierDevice).Client = client
+			case "Speaker":
+				parsedInfrared = &InfraredRemoteSpeakerDevice{}
+				parsedInfrared.(*InfraredRemoteSpeakerDevice).Client = client
+			case "Water Heater":
+				parsedInfrared = &InfraredRemoteWaterHeaterDevice{}
+				parsedInfrared.(*InfraredRemoteWaterHeaterDevice).Client = client
+			case "Robot Vacuum Cleaner":
+				parsedInfrared = &InfraredRemoteRobotVacuumCleanerDevice{}
+				parsedInfrared.(*InfraredRemoteRobotVacuumCleanerDevice).Client = client
+			case "Others":
+				parsedInfrared = &InfraredRemoteOthersDevice{}
+				parsedInfrared.(*InfraredRemoteOthersDevice).Client = client
+			default:
+				parsedInfrared = &InfraredRemoteDevice{}
+				parsedInfrared.(*InfraredRemoteDevice).Client = client
+			}
+
+			err = json.Unmarshal(jsonString, parsedInfrared)
+			if err != nil {
+				return err
+			}
+			parsedInfraredRemoteDevices = append(parsedInfraredRemoteDevices, parsedInfrared)
 		}
+		response.Body.InfraredRemoteList = parsedInfraredRemoteDevices
 
 		return nil
 	}

--- a/device.go
+++ b/device.go
@@ -81,60 +81,78 @@ type InfraredRemoteDevice struct {
 	HubDeviceId string `json:"hubDeviceId"`
 }
 
+// InfraredRemoteAirConditionerDevice represents an infrared remote-controlled air conditioner device.
 type InfraredRemoteAirConditionerDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteTVDevice represents an infrared remote-controlled TV device.
 type InfraredRemoteTVDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteLightDevice represents an infrared remote-controlled light device.
 type InfraredRemoteLightDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteStreamerDevice represents an infrared remote-controlled streamer device.
 type InfraredRemoteStreamerDevice struct {
-	InfraredRemoteDevice
+	InfraredRemoteTVDevice
 }
 
+// InfraredRemoteSetTopBoxDevice represents an infrared remote-controlled set-top box device.
 type InfraredRemoteSetTopBoxDevice struct {
-	InfraredRemoteDevice
+	InfraredRemoteTVDevice
 }
 
+// InfraredRemoteDvdPlayerDevice represents an infrared remote-controlled DVD player device.
 type InfraredRemoteDvdPlayerDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteFanDevice represents an infrared remote-controlled fan device.
 type InfraredRemoteFanDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteProjectorDevice represents an infrared remote-controlled projector device.
 type InfraredRemoteProjectorDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteCameraDevice represents an infrared remote-controlled camera device.
 type InfraredRemoteCameraDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteAirPurifierDevice represents an infrared remote-controlled air purifier device.
 type InfraredRemoteAirPurifierDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteSpeakerDevice represents an infrared remote-controlled speaker device.
 type InfraredRemoteSpeakerDevice struct {
-	InfraredRemoteDevice
+	InfraredRemoteDvdPlayerDevice
 }
 
+// InfraredRemoteWaterHeaterDevice represents an infrared remote-controlled water heater device.
 type InfraredRemoteWaterHeaterDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteRobotVacuumCleanerDevice represents an infrared remote-controlled robot vacuum cleaner device.
 type InfraredRemoteRobotVacuumCleanerDevice struct {
 	InfraredRemoteDevice
 }
 
+// InfraredRemoteOthersDevice represents an infrared remote-controlled device of other types.
 type InfraredRemoteOthersDevice struct {
-	InfraredRemoteDevice
+	Client      *Client
+	DeviceID    string `json:"deviceId"`
+	DeviceName  string `json:"deviceName"`
+	RemoteType  string `json:"remoteType"`
+	HubDeviceId string `json:"hubDeviceId"`
 }
 
 func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {

--- a/device.go
+++ b/device.go
@@ -11,7 +11,8 @@ type GetDevicesResponse struct {
 }
 
 type GetDevicesResponseBody struct {
-	DeviceList []interface{} `json:"deviceList"`
+	DeviceList         []interface{}          `json:"deviceList"`
+	InfraredRemoteList []InfraredRemoteDevice `json:"infraredRemoteList"`
 }
 
 type CommonDevice struct {
@@ -72,6 +73,14 @@ type RemoteDevice struct {
 	CommonDeviceListItem
 }
 
+type InfraredRemoteDevice struct {
+	Client      *Client
+	DeviceID    string `json:"deviceId"`
+	DeviceName  string `json:"deviceName"`
+	RemoteType  string `json:"remoteType"`
+	HubDeviceId string `json:"hubDeviceId"`
+}
+
 func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 	return func(client *Client, bodyBytes []byte) error {
 		err := json.Unmarshal(bodyBytes, response)
@@ -79,6 +88,7 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			return err
 		}
 
+		// Parse the device list
 		var parsedDevices []interface{}
 		for _, deviceInterface := range response.Body.DeviceList {
 			device, ok := deviceInterface.(map[string]interface{})
@@ -136,6 +146,11 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			parsedDevices = append(parsedDevices, parsed)
 		}
 		response.Body.DeviceList = parsedDevices
+
+		// Set the Client for each InfraredRemoteDevice
+		for _, infraredRemoteDevice := range response.Body.InfraredRemoteList {
+			infraredRemoteDevice.Client = client
+		}
 
 		return nil
 	}

--- a/device_control.go
+++ b/device_control.go
@@ -97,22 +97,285 @@ func (device *LockDevice) Unlock() (*CommonResponse, error) {
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-func (InfraredRemoteDevice *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
+// TurnOn sends a command to turn on the InfraredRemoteDevice
+func (device *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
 	request := ControlRequest{
 		CommandType: "command",
 		Command:     "turnOn",
 		Parameter:   "default",
 	}
-	return InfraredRemoteDevice.Client.SendCommand(InfraredRemoteDevice.DeviceID, request)
+	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-func (InfraredRemoteDevice *InfraredRemoteDevice) TurnOff() (*CommonResponse, error) {
+// TurnOff sends a command to turn off the InfraredRemoteDevice
+func (device *InfraredRemoteDevice) TurnOff() (*CommonResponse, error) {
 	request := ControlRequest{
 		CommandType: "command",
 		Command:     "turnOff",
 		Parameter:   "default",
 	}
-	return InfraredRemoteDevice.Client.SendCommand(InfraredRemoteDevice.DeviceID, request)
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+type AirConditionerMode int
+type AirConditionerFanMode int
+type AirConditionerPowerState string
+
+const (
+	AirConditionerModeAuto      = AirConditionerMode(1)
+	AirConditionerModeCool      = AirConditionerMode(2)
+	AirConditionerModeDry       = AirConditionerMode(3)
+	AirConditionerModeFan       = AirConditionerMode(4)
+	AirConditionerModeHeat      = AirConditionerMode(5)
+	AirConditionerFanModeAuto   = AirConditionerFanMode(1)
+	AirConditionerFanModeLow    = AirConditionerFanMode(2)
+	AirConditionerFanModeMedium = AirConditionerFanMode(3)
+	AirConditionerFanModeHigh   = AirConditionerFanMode(4)
+	AirConditionerPowerStateOn  = AirConditionerPowerState("on")
+	AirConditionerPowerStateOff = AirConditionerPowerState("off")
+)
+
+// SetAll sends a command to configure all parameters of the InfraredRemoteAirConditionerDevice
+func (device *InfraredRemoteAirConditionerDevice) SetAll(
+	temperatureCelsius int, mode AirConditionerMode, fan AirConditionerFanMode, powerState AirConditionerPowerState,
+) (*CommonResponse, error) {
+	if temperatureCelsius < 16 || temperatureCelsius > 30 {
+		return nil, fmt.Errorf("invalid temperatureCelsius: %d", temperatureCelsius)
+	}
+	if mode < 1 || mode > 5 {
+		return nil, fmt.Errorf("invalid mode: %d", mode)
+	}
+	if fan < 1 || fan > 4 {
+		return nil, fmt.Errorf("invalid fan: %d", fan)
+	}
+
+	parameter := fmt.Sprintf("%d,%d,%d,%s", temperatureCelsius, mode, fan, powerState)
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "setAll",
+		Parameter:   parameter,
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// SetChannel sends a command to set the channel of the InfraredRemoteTVDevice / InfraredRemoteStreamerDevice / InfraredRemoteSetTopBoxDevice
+func (device *InfraredRemoteTVDevice) SetChannel(channel int) (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "SetChannel",
+		Parameter:   fmt.Sprintf("%d", channel),
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// VolumeAdd sends a command to increase the volume of the InfraredRemoteTVDevice / InfraredRemoteStreamerDevice / InfraredRemoteSetTopBoxDevice
+func (device *InfraredRemoteTVDevice) VolumeAdd() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "volumeAdd",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// VolumeSub sends a command to decrease the volume of the InfraredRemoteTVDevice / InfraredRemoteStreamerDevice / InfraredRemoteSetTopBoxDevice
+func (device *InfraredRemoteTVDevice) VolumeSub() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "volumeSub",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// ChannelAdd sends a command to increase the channel of the InfraredRemoteTVDevice / InfraredRemoteStreamerDevice / InfraredRemoteSetTopBoxDevice
+func (device *InfraredRemoteTVDevice) ChannelAdd() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "channelAdd",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// SetMute sends a command to mute/unmute the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) SetMute() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "setMute",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// FastForward sends a command to fast-forward the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) FastForward() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "FastForward",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Rewind sends a command to rewind the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Rewind() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Rewind",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Next sends a command to play the next track on the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Next() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Next",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Previous sends a command to play the previous track on the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Previous() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Previous",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Pause sends a command to pause the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Pause() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Pause",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Play sends a command to play/resume the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Play() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Play",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Stop sends a command to stop the InfraredRemoteDvdPlayerDevice / InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteDvdPlayerDevice) Stop() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "Stop",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// VolumeAdd sends a command to increase the volume of the InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteSpeakerDevice) VolumeAdd() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "volumeAdd",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// VolumeSub sends a command to decrease the volume of the InfraredRemoteSpeakerDevice
+func (device *InfraredRemoteSpeakerDevice) VolumeSub() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "volumeSub",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Swing sends a command to enable/disable the swing feature of the InfraredRemoteFanDevice
+func (device *InfraredRemoteFanDevice) Swing() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "swing",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Timer sends a command to set the timer of the InfraredRemoteFanDevice
+func (device *InfraredRemoteFanDevice) Timer() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "timer",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// LowSpeed sends a command to set the fan speed to low on the InfraredRemoteFanDevice
+func (device *InfraredRemoteFanDevice) LowSpeed() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "lowSpeed",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// MiddleSpeed sends a command to set the fan speed to middle on the InfraredRemoteFanDevice
+func (device *InfraredRemoteFanDevice) MiddleSpeed() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "middleSpeed",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// HighSpeed sends a command to set the fan speed to high on the InfraredRemoteFanDevice
+func (device *InfraredRemoteFanDevice) HighSpeed() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "highSpeed",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// BrightnessUp sends a command to increase the brightness of the InfraredRemoteLightDevice
+func (device *InfraredRemoteLightDevice) BrightnessUp() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "brightnessUp",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// BrightnessDown sends a command to decrease the brightness of the InfraredRemoteLightDevice
+func (device *InfraredRemoteLightDevice) BrightnessDown() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "brightnessDown",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// CustomCommand sends a user-defined command to the InfraredRemoteOthersDevice
+func (device *InfraredRemoteOthersDevice) CustomCommand(buttonName string) (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "customize",
+		Parameter:   buttonName,
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
 }
 
 func (client *Client) SendCommand(deviceId string, request ControlRequest) (*CommonResponse, error) {

--- a/device_control.go
+++ b/device_control.go
@@ -97,6 +97,24 @@ func (device *LockDevice) Unlock() (*CommonResponse, error) {
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
+func (InfraredRemoteDevice *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "turnOn",
+		Parameter:   "default",
+	}
+	return InfraredRemoteDevice.Client.SendCommand(InfraredRemoteDevice.DeviceID, request)
+}
+
+func (InfraredRemoteDevice *InfraredRemoteDevice) TurnOff() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "turnOff",
+		Parameter:   "default",
+	}
+	return InfraredRemoteDevice.Client.SendCommand(InfraredRemoteDevice.DeviceID, request)
+}
+
 func (client *Client) SendCommand(deviceId string, request ControlRequest) (*CommonResponse, error) {
 	return client.PostRequest("/devices/"+deviceId+"/commands", request)
 }

--- a/examples/command_infrared_device.go
+++ b/examples/command_infrared_device.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/yasu89/switch-bot-api-go"
+)
+
+func main() {
+	token, ok := os.LookupEnv("SWITCH_BOT_TOKEN")
+	if !ok {
+		log.Fatal("SWITCH_BOT_TOKEN environment variable is required")
+	}
+	secret, ok := os.LookupEnv("SWITCH_BOT_SECRET")
+	if !ok {
+		log.Fatal("SWITCH_BOT_SECRET environment variable is required")
+	}
+
+	client := switchbot.NewClient(secret, token)
+
+	response, err := client.GetDevices()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	for _, infraredRemoteDevice := range response.Body.InfraredRemoteList {
+		switch infraredRemoteDevice.(type) {
+		case *switchbot.InfraredRemoteLightDevice:
+			lightDevice := infraredRemoteDevice.(*switchbot.InfraredRemoteLightDevice)
+			log.Printf("Light. DeviceID:%s, DeviceName:%s, RemoteType:%s", lightDevice.DeviceID, lightDevice.DeviceName, lightDevice.RemoteType)
+
+			commandResponse, err := lightDevice.TurnOn()
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			log.Printf("StatusCode: %d, Message: %s", commandResponse.StatusCode, commandResponse.Message)
+		}
+	}
+}

--- a/examples/get_infrared_devices.go
+++ b/examples/get_infrared_devices.go
@@ -24,6 +24,13 @@ func main() {
 	}
 
 	for _, infraredRemoteDevice := range response.Body.InfraredRemoteList {
-		log.Printf("Infrared Remote. DeviceID:%s, DeviceName:%s, RemoteType:%s", infraredRemoteDevice.DeviceID, infraredRemoteDevice.DeviceName, infraredRemoteDevice.RemoteType)
+		switch infraredRemoteDevice.(type) {
+		case *switchbot.InfraredRemoteAirConditionerDevice:
+			infraredRemoteDevice := infraredRemoteDevice.(*switchbot.InfraredRemoteAirConditionerDevice)
+			log.Printf("Air Conditioner. DeviceID:%s, DeviceName:%s, RemoteType:%s", infraredRemoteDevice.DeviceID, infraredRemoteDevice.DeviceName, infraredRemoteDevice.RemoteType)
+		case *switchbot.InfraredRemoteLightDevice:
+			infraredRemoteDevice := infraredRemoteDevice.(*switchbot.InfraredRemoteLightDevice)
+			log.Printf("Light. DeviceID:%s, DeviceName:%s, RemoteType:%s", infraredRemoteDevice.DeviceID, infraredRemoteDevice.DeviceName, infraredRemoteDevice.RemoteType)
+		}
 	}
 }

--- a/examples/get_infrared_devices.go
+++ b/examples/get_infrared_devices.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/yasu89/switch-bot-api-go"
+	"log"
+	"os"
+)
+
+func main() {
+	token, ok := os.LookupEnv("SWITCH_BOT_TOKEN")
+	if !ok {
+		log.Fatal("SWITCH_BOT_TOKEN environment variable is required")
+	}
+	secret, ok := os.LookupEnv("SWITCH_BOT_SECRET")
+	if !ok {
+		log.Fatal("SWITCH_BOT_SECRET environment variable is required")
+	}
+
+	client := switchbot.NewClient(secret, token)
+
+	response, err := client.GetDevices()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	for _, infraredRemoteDevice := range response.Body.InfraredRemoteList {
+		log.Printf("Infrared Remote. DeviceID:%s, DeviceName:%s, RemoteType:%s", infraredRemoteDevice.DeviceID, infraredRemoteDevice.DeviceName, infraredRemoteDevice.RemoteType)
+	}
+}


### PR DESCRIPTION
This pull request introduces support for various infrared remote-controlled devices in the `switch-bot-api-go` library. The changes include adding new device types, updating the response parsing logic, and implementing control commands for these devices.

New device types and response parsing:

* [`device.go`](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R15): Added `InfraredRemoteDevice` and its specific types (e.g., `InfraredRemoteAirConditionerDevice`, `InfraredRemoteTVDevice`) to handle different infrared remote-controlled devices. Updated the `GetDevicesResponseParser` function to parse and initialize these devices correctly. [[1]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R15) [[2]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R76-R165) [[3]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R224-R297)

Control commands for infrared devices:

* [`device_control.go`](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7R100-R380): Implemented various control commands for the new infrared remote-controlled devices, such as `TurnOn`, `TurnOff`, `SetAll` for air conditioners, `SetChannel` for TVs, and other specific commands for different device types.

Examples:

* [`examples/command_infrared_device.go`](diffhunk://#diff-5edf2b5e215fb334e3e81ea7e3e9854d39c1d4d651b9a06eff5386a9b9dfe7acR1-R40): Added an example to demonstrate how to send a command to an infrared remote-controlled light device.
* [`examples/get_infrared_devices.go`](diffhunk://#diff-3b76d79212c566877fe5f0147c2063eb5d35f65246d04d315b35ab31438c13b9R1-R36): Added an example to demonstrate how to retrieve and log information about infrared remote-controlled devices.