### PR TITLE
Update octocov configuration to exclude example files from coverage

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,7 +1,7 @@
 coverage:
   if: true
   exclude:
-    - 'examples/*.go'
+    - 'examples/**/*.go'
 codeToTestRatio:
   if: true
   code:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,7 @@
 coverage:
   if: true
+  exclude:
+    - 'examples/*.go'
 codeToTestRatio:
   if: true
   code:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,7 +1,7 @@
 coverage:
   if: true
   exclude:
-    - 'examples/**/*.go'
+    - 'github.com/yasu89/switch-bot-api-go/examples/**/*.go'
 codeToTestRatio:
   if: true
   code:


### PR DESCRIPTION
This pull request updates the `.octocov.yml` configuration file to exclude certain files from coverage calculations.

Configuration updates:

* [`.octocov.yml`](diffhunk://#diff-d7956660ba186fb6e1b66e9fe7d6f63118e08cae3e10b08488c765dbc0a4c6d6R3-R4): Added an `exclude` section under `coverage` to exclude files matching the pattern `'examples/*.go'` from coverage analysis.