### PR TITLE
Add GetAnyStatusBody to All Device Types for Unified Status Retrieval 

### DIFF
--- a/device_control.go
+++ b/device_control.go
@@ -6,6 +6,12 @@ import (
 	"regexp"
 )
 
+// SwitchableDevice represents a device that can be switched ON or OFF.
+type SwitchableDevice interface {
+	TurnOn() (*CommonResponse, error)
+	TurnOff() (*CommonResponse, error)
+}
+
 type ControlRequest struct {
 	Command     string      `json:"command"`
 	Parameter   interface{} `json:"parameter"`

--- a/device_status.go
+++ b/device_status.go
@@ -4,6 +4,11 @@ import (
 	"encoding/json"
 )
 
+// StatusGettable is an interface that defines a method to get the status of a device as a value of type `any`
+type StatusGettable interface {
+	GetAnyStatusBody() (any, error)
+}
+
 func GetDeviceStatusResponseParser(response interface{}) ResponseParser {
 	return func(client *Client, bodyBytes []byte) error {
 		err := json.Unmarshal(bodyBytes, response)
@@ -36,6 +41,15 @@ func (device *BotDevice) GetStatus() (*BotDeviceStatusResponse, error) {
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *BotDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type CurtainDeviceStatusBody struct {
 	CommonDevice
 	Calibrate     bool   `json:"calibrate"`
@@ -60,6 +74,15 @@ func (device *CurtainDevice) GetStatus() (*CurtainDeviceStatusResponse, error) {
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *CurtainDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type Hub2DeviceStatusBody struct {
 	CommonDevice
 	Temperature float64 `json:"temperature"`
@@ -82,6 +105,15 @@ func (device *Hub2Device) GetStatus() (*Hub2DeviceStatusResponse, error) {
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *Hub2Device) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type MeterDeviceStatusBody struct {
 	CommonDevice
 	Temperature float64 `json:"temperature"`
@@ -102,6 +134,15 @@ func (device *MeterDevice) GetStatus() (*MeterDeviceStatusResponse, error) {
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *MeterDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type MeterProCo2DeviceStatusBody struct {
@@ -127,6 +168,15 @@ func (device *MeterProCo2Device) GetStatus() (*MeterProCo2DeviceStatusResponse, 
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *MeterProCo2Device) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type LockDeviceStatusBody struct {
 	CommonDevice
 	Battery   int    `json:"battery"`
@@ -150,6 +200,15 @@ func (device *LockDevice) GetStatus() (*LockDeviceStatusResponse, error) {
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *LockDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type KeypadDeviceStatusBody struct {
 	CommonDevice
 }
@@ -166,6 +225,15 @@ func (device *KeypadDevice) GetStatus() (*KeypadStatusResponse, error) {
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *KeypadDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type MotionSensorDeviceStatusBody struct {
@@ -191,6 +259,15 @@ func (device *MotionSensorDevice) GetStatus() (*MotionSensorDeviceStatusResponse
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *MotionSensorDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type ContactSensorDeviceStatusBody struct {
 	CommonDevice
 	Battery      int    `json:"battery"`
@@ -214,6 +291,15 @@ func (device *ContactSensorDevice) GetStatus() (*ContactSensorDeviceStatusRespon
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *ContactSensorDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type WaterLeakDetectorDeviceStatusBody struct {
 	CommonDevice
 	Battery int    `json:"battery"`
@@ -233,6 +319,15 @@ func (device *WaterLeakDetectorDevice) GetStatus() (*WaterLeakDetectorDeviceStat
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *WaterLeakDetectorDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type CeilingLightDeviceStatusBody struct {
@@ -255,6 +350,15 @@ func (device *CeilingLightDevice) GetStatus() (*CeilingLightDeviceStatusResponse
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *CeilingLightDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type PlugMiniDeviceStatusBody struct {
@@ -280,6 +384,15 @@ func (device *PlugMiniDevice) GetStatus() (*PlugMiniDeviceStatusResponse, error)
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *PlugMiniDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type PlugDeviceStatusBody struct {
 	CommonDevice
 	Power   string `json:"power"`
@@ -298,6 +411,15 @@ func (device *PlugDevice) GetStatus() (*PlugDeviceStatusResponse, error) {
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *PlugDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type StripLightDeviceStatusBody struct {
@@ -320,6 +442,15 @@ func (device *StripLightDevice) GetStatus() (*StripLightDeviceStatusResponse, er
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *StripLightDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type ColorBulbDeviceStatusBody struct {
@@ -345,6 +476,15 @@ func (device *ColorBulbDevice) GetStatus() (*ColorBulbDeviceStatusResponse, erro
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *ColorBulbDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type RobotVacuumCleanerDeviceStatusBody struct {
 	CommonDevice
 	WorkingStatus string `json:"workingStatus"`
@@ -364,6 +504,15 @@ func (device *RobotVacuumCleanerDevice) GetStatus() (*RobotVacuumCleanerDeviceSt
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RobotVacuumCleanerDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type RobotVacuumCleanerS10DeviceStatusBody struct {
@@ -387,6 +536,15 @@ func (device *RobotVacuumCleanerS10Device) GetStatus() (*RobotVacuumCleanerS10De
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RobotVacuumCleanerS10Device) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type HumidifierDeviceStatusBody struct {
@@ -413,6 +571,15 @@ func (device *HumidifierDevice) GetStatus() (*HumidifierDeviceStatusResponse, er
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *HumidifierDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type EvaporativeHumidifierDeviceFilterElement struct {
@@ -445,6 +612,15 @@ func (device *EvaporativeHumidifierDevice) GetStatus() (*EvaporativeHumidifierDe
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *EvaporativeHumidifierDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type AirPurifierDeviceStatusBody struct {
 	CommonDevice
 	Power     string `json:"power"`
@@ -465,6 +641,15 @@ func (device *AirPurifierDevice) GetStatus() (*AirPurifierDeviceStatusResponse, 
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *AirPurifierDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type BlindTiltDeviceStatusBody struct {
@@ -489,6 +674,15 @@ func (device *BlindTiltDevice) GetStatus() (*BlindTiltDeviceStatusResponse, erro
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *BlindTiltDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type BatteryCirculatorFanDeviceStatusBody struct {
@@ -518,6 +712,15 @@ func (device *BatteryCirculatorFanDevice) GetStatus() (*BatteryCirculatorFanDevi
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *BatteryCirculatorFanDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type CirculatorFanDeviceStatusBody struct {
 	CommonDevice
 	Mode                string `json:"mode"`
@@ -543,6 +746,15 @@ func (device *CirculatorFanDevice) GetStatus() (*CirculatorFanDeviceStatusRespon
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *CirculatorFanDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type RollerShadeDeviceStatusBody struct {
 	CommonDevice
 	Version       string `json:"version"`
@@ -564,6 +776,15 @@ func (device *RollerShadeDevice) GetStatus() (*RollerShadeDeviceStatusResponse, 
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RollerShadeDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }
 
 type RelaySwitch1PMDeviceStatusBody struct {
@@ -590,6 +811,15 @@ func (device *RelaySwitch1PMDevice) GetStatus() (*RelaySwitch1PMDeviceStatusResp
 	return response, nil
 }
 
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RelaySwitch1PMDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type RelaySwitch1DeviceStatusBody struct {
 	CommonDevice
 	SwitchStatus int    `json:"switchStatus"`
@@ -608,4 +838,13 @@ func (device *RelaySwitch1Device) GetStatus() (*RelaySwitch1DeviceStatusResponse
 		return nil, err
 	}
 	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RelaySwitch1Device) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
 }

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -9,7 +9,7 @@ import (
 	switchbot "github.com/yasu89/switch-bot-api-go"
 )
 
-func TestGetStatus(t *testing.T) {
+func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	t.Run("BotDevice", func(t *testing.T) {
 		testServer := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +64,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("CurtainDevice", func(t *testing.T) {
@@ -124,6 +131,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("Hub2Device", func(t *testing.T) {
@@ -180,6 +194,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("MeterDevice", func(t *testing.T) {
@@ -236,6 +257,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("MeterProCo2Device", func(t *testing.T) {
@@ -294,6 +322,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("LockDevice", func(t *testing.T) {
@@ -352,6 +387,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("KeypadDevice", func(t *testing.T) {
@@ -400,6 +442,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("MotionSensorDevice", func(t *testing.T) {
@@ -458,6 +507,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("ContactSensorDevice", func(t *testing.T) {
@@ -516,6 +572,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("WaterLeakDetectorDevice", func(t *testing.T) {
@@ -569,6 +632,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("CeilingLightDevice", func(t *testing.T) {
@@ -625,6 +695,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("PlugMiniDevice", func(t *testing.T) {
@@ -683,6 +760,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("PlugDevice", func(t *testing.T) {
@@ -735,6 +819,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("StripLightDevice", func(t *testing.T) {
@@ -791,6 +882,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("ColorBulbDevice", func(t *testing.T) {
@@ -849,6 +947,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("RobotVacuumCleanerDevice", func(t *testing.T) {
@@ -903,6 +1008,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("RobotVacuumCleanerS10Device", func(t *testing.T) {
@@ -961,6 +1073,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("HumidifierDevice", func(t *testing.T) {
@@ -1025,6 +1144,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("EvaporativeHumidifierDevice", func(t *testing.T) {
@@ -1093,6 +1219,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("AirPurifierDevice", func(t *testing.T) {
@@ -1149,6 +1282,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("BlindTiltDevice", func(t *testing.T) {
@@ -1209,6 +1349,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("BatteryCirculatorFanDevice", func(t *testing.T) {
@@ -1275,6 +1422,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("CirculatorFanDevice", func(t *testing.T) {
@@ -1337,6 +1491,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("RollerShadeDevice", func(t *testing.T) {
@@ -1395,6 +1556,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("RelaySwitch1PMDevice", func(t *testing.T) {
@@ -1455,6 +1623,13 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
 	})
 
 	t.Run("RelaySwitch1Device", func(t *testing.T) {
@@ -1507,8 +1682,14 @@ func TestGetStatus(t *testing.T) {
 
 		assertResponse(t, &status.CommonResponse)
 		assertBody(t, status.Body, expectedBody)
-	})
 
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertBody(t, anyStatus, expectedBody)
+	})
 }
 
 func assertResponse(t *testing.T, response *switchbot.CommonResponse) {


### PR DESCRIPTION
This pull request introduces two major changes: the addition of a new `GetAnyStatusBody` method to various device types for unified status retrieval and the implementation of tests to verify this functionality. These changes improve the codebase's extensibility and ensure correctness through testing.

### New `GetAnyStatusBody` Method for Unified Status Retrieval:
* Added the `GetAnyStatusBody` method to 23 device types (e.g., `BotDevice`, `CurtainDevice`, `MeterDevice`, etc.) in `device_status.go`. This method provides a generic way to retrieve the status of a device as a value of type `any`, enhancing code reusability. [[1]](diffhunk://#diff-5e6f20f1c59430455d2ee670f12779678e402b6c0ac17b9a562126b25a441b2bR44-R52) [[2]](diffhunk://#diff-5e6f20f1c59430455d2ee670f12779678e402b6c0ac17b9a562126b25a441b2bR77-R85) [[3]](diffhunk://#diff-5e6f20f1c59430455d2ee670f12779678e402b6c0ac17b9a562126b25a441b2bR139-R147) ...)

### Testing Enhancements:
* Updated the test function in `device_status_test.go` to include test cases for the new `GetAnyStatusBody` method for various device types, ensuring its correctness. [[1]](diffhunk://#diff-0ca9a2dec6e912aba5a8f3d9a65c345e6374758e93b7652b3d9fe81fae8fa434L12-R12) [[2]](diffhunk://#diff-0ca9a2dec6e912aba5a8f3d9a65c345e6374758e93b7652b3d9fe81fae8fa434R67-R73) [[3]](diffhunk://#diff-0ca9a2dec6e912aba5a8f3d9a65c345e6374758e93b7652b3d9fe81fae8fa434R134-R140) [[4]](diffhunk://#diff-0ca9a2dec6e912aba5a8f3d9a65c345e6374758e93b7652b3d9fe81fae8fa434R197-R203)