### PR TITLE
Add DeviceIdGettable interface and implement GetDeviceId method commonDevice

### DIFF
--- a/device.go
+++ b/device.go
@@ -15,10 +15,18 @@ type GetDevicesResponseBody struct {
 	InfraredRemoteList []interface{} `json:"infraredRemoteList"`
 }
 
+type DeviceIdGettable interface {
+	GetDeviceId() string
+}
+
 type CommonDevice struct {
 	DeviceID    string `json:"deviceId"`
 	DeviceType  string `json:"deviceType"`
 	HubDeviceId string `json:"hubDeviceId"`
+}
+
+func (device *CommonDevice) GetDeviceId() string {
+	return device.DeviceID
 }
 
 type CommonDeviceListItem struct {

--- a/device.go
+++ b/device.go
@@ -15,8 +15,8 @@ type GetDevicesResponseBody struct {
 	InfraredRemoteList []interface{} `json:"infraredRemoteList"`
 }
 
-type DeviceIdGettable interface {
-	GetDeviceId() string
+type DeviceIDGettable interface {
+	GetDeviceID() string
 }
 
 type CommonDevice struct {
@@ -25,7 +25,7 @@ type CommonDevice struct {
 	HubDeviceId string `json:"hubDeviceId"`
 }
 
-func (device *CommonDevice) GetDeviceId() string {
+func (device *CommonDevice) GetDeviceID() string {
 	return device.DeviceID
 }
 


### PR DESCRIPTION
This pull request introduces a new interface, `DeviceIdGettable`, and updates the `CommonDevice` struct to implement this interface by adding a `GetDeviceId` method. These changes aim to improve code reusability and standardize how device IDs are accessed.

### Interface addition and implementation:

* Added a new interface `DeviceIdGettable` with a single method, `GetDeviceId`, to define a standard way to retrieve device IDs. (`device.go`, [device.goR18-R31](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R18-R31))
* Updated the `CommonDevice` struct to implement the `DeviceIdGettable` interface by adding a `GetDeviceId` method that returns the `DeviceID` field. (`device.go`, [device.goR18-R31](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R18-R31))