### PR TITLE
Implement GetDeviceID to InfraredRemoteDevice and InfraredRemoteOthersDevice

### DIFF
--- a/device.go
+++ b/device.go
@@ -197,6 +197,10 @@ type InfraredRemoteDevice struct {
 	HubDeviceId string `json:"hubDeviceId"`
 }
 
+func (device *InfraredRemoteDevice) GetDeviceID() string {
+	return device.DeviceID
+}
+
 // InfraredRemoteAirConditionerDevice represents an infrared remote-controlled air conditioner device.
 type InfraredRemoteAirConditionerDevice struct {
 	InfraredRemoteDevice

--- a/device.go
+++ b/device.go
@@ -275,6 +275,10 @@ type InfraredRemoteOthersDevice struct {
 	HubDeviceId string `json:"hubDeviceId"`
 }
 
+func (device *InfraredRemoteOthersDevice) GetDeviceID() string {
+	return device.DeviceID
+}
+
 func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 	return func(client *Client, bodyBytes []byte) error {
 		err := json.Unmarshal(bodyBytes, response)


### PR DESCRIPTION
This pull request introduces new methods to retrieve the `DeviceID` for specific device types in the `device.go` file. These changes improve code clarity and provide a consistent way to access the `DeviceID` for different device structs.

Enhancements to device structs:

* `InfraredRemoteDevice` struct: Added a `GetDeviceID` method to return the `DeviceID` property, improving encapsulation and providing a standard way to access the `DeviceID`.
* `InfraredRemoteOthersDevice` struct: Added a `GetDeviceID` method to return the `DeviceID` property, aligning with the same pattern introduced for other device structs.