### PR TITLE
Implements SwitchBot API mock helper.

### DIFF
--- a/device_control_test.go
+++ b/device_control_test.go
@@ -1,12 +1,10 @@
 package switchbot_test
 
 import (
-	"encoding/json"
 	"github.com/yasu89/switch-bot-api-go"
+	"github.com/yasu89/switch-bot-api-go/helpers"
 	"image/color"
 	"net/http"
-	"net/http/httptest"
-	"reflect"
 	"testing"
 )
 
@@ -35,7 +33,9 @@ func TestBotDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -52,6 +52,7 @@ func TestBotDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -88,7 +89,9 @@ func TestCurtainDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -105,6 +108,7 @@ func TestCurtainDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -148,7 +152,9 @@ func TestKeypadDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -165,6 +171,7 @@ func TestKeypadDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -189,7 +196,9 @@ func TestLockDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -206,6 +215,7 @@ func TestLockDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -249,7 +259,9 @@ func TestCeilingLightDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -266,6 +278,7 @@ func TestCeilingLightDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -294,7 +307,9 @@ func TestStripLightDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -311,6 +326,7 @@ func TestStripLightDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -346,7 +362,9 @@ func TestColorBulbDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -363,6 +381,7 @@ func TestColorBulbDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -384,7 +403,9 @@ func TestRobotVacuumCleanerDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -401,6 +422,7 @@ func TestRobotVacuumCleanerDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -451,7 +473,9 @@ func TestRobotVacuumCleanerS10Device(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -468,6 +492,7 @@ func TestRobotVacuumCleanerS10Device(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -496,7 +521,9 @@ func TestHumidifierDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -513,6 +540,7 @@ func TestHumidifierDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -541,7 +569,9 @@ func TestEvaporativeHumidifierDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -558,6 +588,7 @@ func TestEvaporativeHumidifierDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -593,7 +624,9 @@ func TestAirPurifierDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -610,6 +643,7 @@ func TestAirPurifierDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -638,7 +672,9 @@ func TestBlindTiltDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -655,6 +691,7 @@ func TestBlindTiltDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -690,7 +727,9 @@ func TestBatteryCirculatorFanDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -707,6 +746,7 @@ func TestBatteryCirculatorFanDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -742,7 +782,9 @@ func TestCirculatorFanDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -759,6 +801,7 @@ func TestCirculatorFanDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -780,7 +823,9 @@ func TestRollerShadeDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -797,6 +842,7 @@ func TestRollerShadeDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -825,7 +871,9 @@ func TestRelaySwitch1PMDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -842,6 +890,7 @@ func TestRelaySwitch1PMDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -870,7 +919,9 @@ func TestRelaySwitch1Device(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -887,6 +938,7 @@ func TestRelaySwitch1Device(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -922,7 +974,9 @@ func TestInfraredRemoteAirConditionerDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -938,6 +992,7 @@ func TestInfraredRemoteAirConditionerDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -959,7 +1014,9 @@ func TestInfraredRemoteTVDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -975,6 +1032,7 @@ func TestInfraredRemoteTVDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
 }
@@ -996,7 +1054,9 @@ func TestInfraredRemoteOthersDevice(t *testing.T) {
 
 	for _, testData := range testDataList {
 		t.Run(testData.name, func(t *testing.T) {
-			testServer := newTestCommandServer(t, testData.expectedBody)
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1010,38 +1070,7 @@ func TestInfraredRemoteOthersDevice(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
 		})
 	}
-}
-
-func newTestCommandServer(t *testing.T, expectedBody string) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/devices/ABCDEF123456/commands" {
-				t.Fatalf("Expected path '/devices/ABCDEF123456/commands', got '%s'", r.URL.Path)
-			}
-
-			var expectedObject map[string]interface{}
-			if err := json.Unmarshal([]byte(expectedBody), &expectedObject); err != nil {
-				t.Fatalf("Failed to unmarshal expected body: %v", err)
-			}
-
-			var actualObject map[string]interface{}
-			if err := json.NewDecoder(r.Body).Decode(&actualObject); err != nil {
-				t.Fatalf("Failed to decode actual body: %v", err)
-			}
-
-			if !reflect.DeepEqual(expectedObject, actualObject) {
-				t.Fatalf("Expected body %v, got %v", expectedObject, actualObject)
-			}
-
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {},
-    "message": "success"
-}`))
-		}),
-	)
 }

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -1,38 +1,26 @@
 package switchbot_test
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
-	switchbot "github.com/yasu89/switch-bot-api-go"
+	"github.com/yasu89/switch-bot-api-go"
+	"github.com/yasu89/switch-bot-api-go/helpers"
 )
 
 func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	t.Run("BotDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123456/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123456/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123456",
-		"deviceType": "Bot",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"battery": 100,
-		"version": "1.0",
-		"deviceMode": "pressMode"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Bot",
+			"hubDeviceId": "123456789",
+			"power":       "ON",
+			"battery":     100,
+			"version":     "1.0",
+			"deviceMode":  "pressMode",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -49,6 +37,8 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.BotDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -74,30 +64,19 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("CurtainDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123457/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123457/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123457",
-		"deviceType": "Curtain",
-		"hubDeviceId": "123456789",
-		"calibrate": true,
-		"group": false,
-		"moving": false,
-		"battery": 80,
-		"version": "1.1",
-		"slidePosition": "50"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":      "ABCDEF123456",
+			"deviceType":    "Curtain",
+			"hubDeviceId":   "123456789",
+			"calibrate":     true,
+			"group":         false,
+			"moving":        false,
+			"battery":       80,
+			"version":       "1.1",
+			"slidePosition": "50",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -105,7 +84,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.CurtainDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123457",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -115,9 +94,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.CurtainDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123457",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Curtain",
 				HubDeviceId: "123456789",
 			},
@@ -141,28 +122,17 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("Hub2Device", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123458/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123458/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123458",
-		"deviceType": "Hub 2",
-		"hubDeviceId": "123456789",
-		"temperature": 22.5,
-		"lightLevel": 300,
-		"version": "1.2",
-		"humidity": 60
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Hub 2",
+			"hubDeviceId": "123456789",
+			"temperature": 22.5,
+			"lightLevel":  300,
+			"version":     "1.2",
+			"humidity":    60,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -170,7 +140,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.Hub2Device{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123458",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -180,9 +150,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.Hub2DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123458",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Hub 2",
 				HubDeviceId: "123456789",
 			},
@@ -204,28 +176,17 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("MeterDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123459/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123459/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123459",
-		"deviceType": "MeterPlus",
-		"hubDeviceId": "123456789",
-		"temperature": 25.5,
-		"version": "1.3",
-		"battery": 90,
-		"humidity": 50
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "MeterPlus",
+			"hubDeviceId": "123456789",
+			"temperature": 25.5,
+			"version":     "1.3",
+			"battery":     90,
+			"humidity":    50,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -233,7 +194,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.MeterDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123459",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -243,9 +204,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.MeterDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123459",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "MeterPlus",
 				HubDeviceId: "123456789",
 			},
@@ -267,29 +230,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("MeterProCo2Device", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123460/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123460/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123460",
-		"deviceType": "MeterPro(CO2)",
-		"hubDeviceId": "123456789",
-		"temperature": 23.0,
-		"version": "1.4",
-		"battery": 85,
-		"humidity": 55,
-		"CO2": 400
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "MeterPro(CO2)",
+			"hubDeviceId": "123456789",
+			"temperature": 23.0,
+			"version":     "1.4",
+			"battery":     85,
+			"humidity":    55,
+			"CO2":         400,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -297,7 +249,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.MeterProCo2Device{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123460",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -307,9 +259,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.MeterProCo2DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123460",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "MeterPro(CO2)",
 				HubDeviceId: "123456789",
 			},
@@ -332,29 +286,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("LockDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123461/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123461/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123461",
-		"deviceType": "Smart Lock",
-		"hubDeviceId": "123456789",
-		"battery": 70,
-		"version": "1.5",
-		"lockState": "locked",
-		"doorState": "closed",
-		"calibrate": true
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Smart Lock",
+			"hubDeviceId": "123456789",
+			"battery":     70,
+			"version":     "1.5",
+			"lockState":   "locked",
+			"doorState":   "closed",
+			"calibrate":   true,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -362,7 +305,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.LockDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123461",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -372,9 +315,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.LockDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123461",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Smart Lock",
 				HubDeviceId: "123456789",
 			},
@@ -397,24 +342,13 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("KeypadDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123462/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123462/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123462",
-		"deviceType": "Keypad Touch",
-		"hubDeviceId": "123456789"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Keypad Touch",
+			"hubDeviceId": "123456789",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -422,7 +356,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.KeypadDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123462",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -432,9 +366,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.KeypadDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123462",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Keypad Touch",
 				HubDeviceId: "123456789",
 			},
@@ -452,29 +388,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("MotionSensorDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123463/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123463/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123463",
-		"deviceType": "Motion Sensor",
-		"hubDeviceId": "123456789",
-		"battery": 80,
-		"version": "1.6",
-		"moveDetected": true,
-		"openState": "closed",
-		"brightness": "bright"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":     "ABCDEF123456",
+			"deviceType":   "Motion Sensor",
+			"hubDeviceId":  "123456789",
+			"battery":      80,
+			"version":      "1.6",
+			"moveDetected": true,
+			"openState":    "closed",
+			"brightness":   "bright",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -482,7 +407,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.MotionSensorDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123463",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -492,9 +417,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.MotionSensorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123463",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Motion Sensor",
 				HubDeviceId: "123456789",
 			},
@@ -517,29 +444,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("ContactSensorDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123464/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123464/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123464",
-		"deviceType": "Contact Sensor",
-		"hubDeviceId": "123456789",
-		"battery": 75,
-		"version": "1.7",
-		"moveDetected": false,
-		"openState": "open",
-		"brightness": "dim"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":     "ABCDEF123456",
+			"deviceType":   "Contact Sensor",
+			"hubDeviceId":  "123456789",
+			"battery":      75,
+			"version":      "1.7",
+			"moveDetected": false,
+			"openState":    "open",
+			"brightness":   "dim",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -547,7 +463,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.ContactSensorDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123464",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -557,9 +473,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.ContactSensorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123464",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Contact Sensor",
 				HubDeviceId: "123456789",
 			},
@@ -582,26 +500,16 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("WaterLeakDetectorDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123465/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123465/status', got '%s'", r.URL.Path)
-				}
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceId": "ABCDEF123465",
-        "deviceType": "Water Detector",
-        "hubDeviceId": "123456789",
-        "battery": 60,
-        "version": "1.8",
-		"status": true
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Water Detector",
+			"hubDeviceId": "123456789",
+			"battery":     60,
+			"version":     "1.8",
+			"status":      true,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -609,7 +517,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.WaterLeakDetectorDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123465",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -619,9 +527,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.WaterLeakDetectorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123465",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Water Detector",
 				HubDeviceId: "123456789",
 			},
@@ -642,28 +552,17 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("CeilingLightDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123466/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123466/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123466",
-		"deviceType": "Ceiling Light",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"version": "1.9",
-		"brightness": 80,
-		"colorTemperature": 4000
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":         "ABCDEF123456",
+			"deviceType":       "Ceiling Light",
+			"hubDeviceId":      "123456789",
+			"power":            "ON",
+			"version":          "1.9",
+			"brightness":       80,
+			"colorTemperature": 4000,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -671,7 +570,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.CeilingLightDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123466",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -681,9 +580,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.CeilingLightDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123466",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Ceiling Light",
 				HubDeviceId: "123456789",
 			},
@@ -705,29 +606,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("PlugMiniDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123467/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123467/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123467",
-		"deviceType": "Plug Mini (JP)",
-		"hubDeviceId": "123456789",
-		"voltage": 220.5,
-		"version": "2.0",
-		"weight": 1.2,
-		"electricityOfDay": 15,
-		"electricCurrent": 0.5
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":         "ABCDEF123456",
+			"deviceType":       "Plug Mini (JP)",
+			"hubDeviceId":      "123456789",
+			"voltage":          220.5,
+			"version":          "2.0",
+			"weight":           1.2,
+			"electricityOfDay": 15,
+			"electricCurrent":  0.5,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -735,7 +625,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.PlugMiniDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123467",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -745,9 +635,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.PlugMiniDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123467",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Plug Mini (JP)",
 				HubDeviceId: "123456789",
 			},
@@ -770,26 +662,15 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("PlugDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123468/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123468/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123468",
-		"deviceType": "Plug",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"version": "2.1"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Plug",
+			"hubDeviceId": "123456789",
+			"power":       "ON",
+			"version":     "2.1",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -797,7 +678,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.PlugDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123468",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -807,9 +688,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.PlugDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123468",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Plug",
 				HubDeviceId: "123456789",
 			},
@@ -829,28 +712,17 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("StripLightDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123469/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123469/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123469",
-		"deviceType": "Strip Light",
-		"hubDeviceId": "123456789",
-		"power": "OFF",
-		"version": "2.2",
-		"brightness": 70,
-		"color": "#FF5733"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Strip Light",
+			"hubDeviceId": "123456789",
+			"power":       "OFF",
+			"version":     "2.2",
+			"brightness":  70,
+			"color":       "#FF5733",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -858,7 +730,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.StripLightDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123469",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -868,9 +740,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.StripLightDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123469",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Strip Light",
 				HubDeviceId: "123456789",
 			},
@@ -892,29 +766,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("ColorBulbDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123470/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123470/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123470",
-		"deviceType": "Color Bulb",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"brightness": 90,
-		"version": "2.3",
-		"color": "#00FF00",
-		"colorTemperature": 5000
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":         "ABCDEF123456",
+			"deviceType":       "Color Bulb",
+			"hubDeviceId":      "123456789",
+			"power":            "ON",
+			"brightness":       90,
+			"version":          "2.3",
+			"color":            "#00FF00",
+			"colorTemperature": 5000,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -922,7 +785,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.ColorBulbDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123470",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -932,9 +795,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.ColorBulbDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123470",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Color Bulb",
 				HubDeviceId: "123456789",
 			},
@@ -957,27 +822,16 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("RobotVacuumCleanerDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123471/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123471/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123471",
-		"deviceType": "Robot Vacuum Cleaner S1",
-		"hubDeviceId": "123456789",
-		"workingStatus": "cleaning",
-		"onlineStatus": "online",
-		"battery": 75
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":      "ABCDEF123456",
+			"deviceType":    "Robot Vacuum Cleaner S1",
+			"hubDeviceId":   "123456789",
+			"workingStatus": "cleaning",
+			"onlineStatus":  "online",
+			"battery":       75,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -985,7 +839,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.RobotVacuumCleanerDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123471",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -995,9 +849,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.RobotVacuumCleanerDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123471",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Robot Vacuum Cleaner S1",
 				HubDeviceId: "123456789",
 			},
@@ -1018,29 +874,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("RobotVacuumCleanerS10Device", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123472/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123472/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123472",
-		"deviceType": "Robot Vacuum Cleaner S10",
-		"hubDeviceId": "123456789",
-		"workingStatus": "mopping",
-		"onlineStatus": "offline",
-		"battery": 50,
-		"waterBaseBattery": 80,
-		"taskType": "mop"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":         "ABCDEF123456",
+			"deviceType":       "Robot Vacuum Cleaner S10",
+			"hubDeviceId":      "123456789",
+			"workingStatus":    "mopping",
+			"onlineStatus":     "offline",
+			"battery":          50,
+			"waterBaseBattery": 80,
+			"taskType":         "mop",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1048,7 +893,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.RobotVacuumCleanerS10Device{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123472",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1058,9 +903,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.RobotVacuumCleanerS10DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123472",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Robot Vacuum Cleaner S10",
 				HubDeviceId: "123456789",
 			},
@@ -1083,32 +930,21 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("HumidifierDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123473/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123473/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123473",
-		"deviceType": "Humidifier",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"humidity": 45,
-		"temperature": 22,
-		"nebulizationEfficiency": 3,
-		"auto": true,
-		"childLock": false,
-		"sound": true,
-		"lackWater": false
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":               "ABCDEF123456",
+			"deviceType":             "Humidifier",
+			"hubDeviceId":            "123456789",
+			"power":                  "ON",
+			"humidity":               45,
+			"temperature":            22,
+			"nebulizationEfficiency": 3,
+			"auto":                   true,
+			"childLock":              false,
+			"sound":                  true,
+			"lackWater":              false,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1116,7 +952,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.HumidifierDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123473",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1126,9 +962,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.HumidifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123473",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Humidifier",
 				HubDeviceId: "123456789",
 			},
@@ -1154,34 +992,23 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("EvaporativeHumidifierDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123474/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123474/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123474",
-		"deviceType": "Humidifier2",
-		"hubDeviceId": "123456789",
-		"power": "OFF",
-		"humidity": 50,
-		"mode": 2,
-		"drying": false,
-		"childLock": true,
-		"filterElement": {
-			"effectiveUsageHours": 100,
-			"usedHours": 20
-		},
-		"version": 1
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Humidifier2",
+			"hubDeviceId": "123456789",
+			"power":       "OFF",
+			"humidity":    50,
+			"mode":        2,
+			"drying":      false,
+			"childLock":   true,
+			"filterElement": map[string]interface{}{
+				"effectiveUsageHours": 100,
+				"usedHours":           20,
+			},
+			"version": 1,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1189,7 +1016,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.EvaporativeHumidifierDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123474",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1199,9 +1026,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.EvaporativeHumidifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123474",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Humidifier2",
 				HubDeviceId: "123456789",
 			},
@@ -1229,28 +1058,17 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("AirPurifierDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123475/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123475/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123475",
-		"deviceType": "Air Purifier VOC",
-		"hubDeviceId": "123456789",
-		"power": "ON",
-		"version": "1.0",
-		"mode": 3,
-		"childLock": false
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Air Purifier VOC",
+			"hubDeviceId": "123456789",
+			"power":       "ON",
+			"version":     "1.0",
+			"mode":        3,
+			"childLock":   false,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1258,7 +1076,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.AirPurifierDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123475",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1268,9 +1086,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.AirPurifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123475",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Air Purifier VOC",
 				HubDeviceId: "123456789",
 			},
@@ -1292,30 +1112,19 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("BlindTiltDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123476/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123476/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123476",
-		"deviceType": "Blind Tilt",
-		"hubDeviceId": "123456789",
-		"version": 1,
-		"calibrate": true,
-		"group": false,
-		"moving": false,
-		"direction": "up",
-		"slidePosition": 50
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":      "ABCDEF123456",
+			"deviceType":    "Blind Tilt",
+			"hubDeviceId":   "123456789",
+			"version":       1,
+			"calibrate":     true,
+			"group":         false,
+			"moving":        false,
+			"direction":     "up",
+			"slidePosition": 50,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1323,7 +1132,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.BlindTiltDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123476",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1333,9 +1142,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.BlindTiltDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123476",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Blind Tilt",
 				HubDeviceId: "123456789",
 			},
@@ -1359,33 +1170,22 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("BatteryCirculatorFanDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123477/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123477/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123477",
-		"deviceType": "Battery Circulator Fan",
-		"hubDeviceId": "123456789",
-		"mode": "normal",
-		"version": "1.0",
-		"battery": 85,
-		"power": "ON",
-		"nightStatus": "OFF",
-		"oscillation": "ON",
-		"verticalOscillation": "OFF",
-		"chargingStatus": "charging",
-		"fanSpeed": 3
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":            "ABCDEF123456",
+			"deviceType":          "Battery Circulator Fan",
+			"hubDeviceId":         "123456789",
+			"mode":                "normal",
+			"version":             "1.0",
+			"battery":             85,
+			"power":               "ON",
+			"nightStatus":         "OFF",
+			"oscillation":         "ON",
+			"verticalOscillation": "OFF",
+			"chargingStatus":      "charging",
+			"fanSpeed":            3,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1393,7 +1193,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.BatteryCirculatorFanDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123477",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1403,9 +1203,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.BatteryCirculatorFanDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123477",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Battery Circulator Fan",
 				HubDeviceId: "123456789",
 			},
@@ -1432,31 +1234,20 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("CirculatorFanDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123478/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123478/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123478",
-		"deviceType": "Circulator Fan",
-		"hubDeviceId": "123456789",
-		"mode": "eco",
-		"version": "1.1",
-		"power": "OFF",
-		"nightStatus": "ON",
-		"oscillation": "OFF",
-		"verticalOscillation": "ON",
-		"fanSpeed": 2
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":            "ABCDEF123456",
+			"deviceType":          "Circulator Fan",
+			"hubDeviceId":         "123456789",
+			"mode":                "eco",
+			"version":             "1.1",
+			"power":               "OFF",
+			"nightStatus":         "ON",
+			"oscillation":         "OFF",
+			"verticalOscillation": "ON",
+			"fanSpeed":            2,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1464,7 +1255,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.CirculatorFanDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123478",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1474,9 +1265,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.CirculatorFanDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123478",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Circulator Fan",
 				HubDeviceId: "123456789",
 			},
@@ -1501,29 +1294,18 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("RollerShadeDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123479/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123479/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123479",
-		"deviceType": "Roller Shade",
-		"hubDeviceId": "123456789",
-		"version": "1.0",
-		"calibrate": true,
-		"battery": 90,
-		"moving": false,
-		"slidePosition": 75
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":      "ABCDEF123456",
+			"deviceType":    "Roller Shade",
+			"hubDeviceId":   "123456789",
+			"version":       "1.0",
+			"calibrate":     true,
+			"battery":       90,
+			"moving":        false,
+			"slidePosition": 75,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1531,7 +1313,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.RollerShadeDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123479",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1541,9 +1323,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.RollerShadeDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123479",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Roller Shade",
 				HubDeviceId: "123456789",
 			},
@@ -1566,30 +1350,19 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("RelaySwitch1PMDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123480/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123480/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123480",
-		"deviceType": "Relay Switch 1PM",
-		"hubDeviceId": "123456789",
-		"switchStatus": 1,
-		"voltage": 220,
-		"version": "1.1",
-		"power": 50,
-		"usedElectricity": 100,
-		"electricCurrent": 10
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":        "ABCDEF123456",
+			"deviceType":      "Relay Switch 1PM",
+			"hubDeviceId":     "123456789",
+			"switchStatus":    1,
+			"voltage":         220,
+			"version":         "1.1",
+			"power":           50,
+			"usedElectricity": 100,
+			"electricCurrent": 10,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1597,7 +1370,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.RelaySwitch1PMDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123480",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1607,9 +1380,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.RelaySwitch1PMDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123480",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Relay Switch 1PM",
 				HubDeviceId: "123456789",
 			},
@@ -1633,26 +1408,15 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 	})
 
 	t.Run("RelaySwitch1Device", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/devices/ABCDEF123481/status" {
-					t.Fatalf("Expected path '/devices/ABCDEF123481/status', got '%s'", r.URL.Path)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-	"body": {
-		"deviceId": "ABCDEF123481",
-		"deviceType": "Relay Switch 1",
-		"hubDeviceId": "123456789",
-		"switchStatus": 0,
-		"version": "1.2"
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":     "ABCDEF123456",
+			"deviceType":   "Relay Switch 1",
+			"hubDeviceId":  "123456789",
+			"switchStatus": 0,
+			"version":      "1.2",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -1660,7 +1424,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		device := &switchbot.RelaySwitch1Device{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
-					DeviceID: "ABCDEF123481",
+					DeviceID: "ABCDEF123456",
 				},
 				Client: client,
 			},
@@ -1670,9 +1434,11 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+
 		expectedBody := &switchbot.RelaySwitch1DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
-				DeviceID:    "ABCDEF123481",
+				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Relay Switch 1",
 				HubDeviceId: "123456789",
 			},

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -1,6 +1,7 @@
 package switchbot_test
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.BotDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -94,7 +95,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.CurtainDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -150,7 +151,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.Hub2DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -204,7 +205,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.MeterDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -259,7 +260,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.MeterProCo2DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -315,7 +316,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.LockDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -366,7 +367,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.KeypadDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -417,7 +418,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.MotionSensorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -473,7 +474,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.ContactSensorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -527,7 +528,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.WaterLeakDetectorDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -580,7 +581,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.CeilingLightDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -635,7 +636,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.PlugMiniDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -688,7 +689,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.PlugDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -740,7 +741,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.StripLightDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -795,7 +796,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.ColorBulbDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -849,7 +850,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.RobotVacuumCleanerDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -903,7 +904,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.RobotVacuumCleanerS10DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -962,7 +963,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.HumidifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1026,7 +1027,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.EvaporativeHumidifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1086,7 +1087,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.AirPurifierDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1142,7 +1143,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.BlindTiltDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1203,7 +1204,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.BatteryCirculatorFanDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1265,7 +1266,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.CirculatorFanDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1323,7 +1324,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.RollerShadeDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1380,7 +1381,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.RelaySwitch1PMDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
@@ -1434,7 +1435,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		switchBotMock.AssertCallCount("GET", "/devices/ABCDEF123456/status", 1)
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
 		expectedBody := &switchbot.RelaySwitch1DeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{

--- a/device_test.go
+++ b/device_test.go
@@ -2,6 +2,7 @@ package switchbot_test
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -14,13 +15,18 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("BotDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ABCDEF123456",
-			"deviceType":         "Bot",
-			"hubDeviceId":        "123456789",
-			"deviceName":         "BotDevice",
-			"enableCloudService": true,
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Bot",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "BotDevice",
+					"enableCloudService": true,
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -30,6 +36,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.BotDevice{
@@ -49,18 +57,23 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("CurtainDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ABCDEF123456",
-			"deviceType":         "Curtain3",
-			"hubDeviceId":        "123456789",
-			"deviceName":         "CurtainDevice",
-			"enableCloudService": false,
-			"curtainDevicesIds":  []string{"BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
-			"calibrate":          true,
-			"group":              true,
-			"master":             false,
-			"openDirection":      "left",
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Curtain3",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "CurtainDevice",
+					"enableCloudService": false,
+					"curtainDevicesIds":  []string{"BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
+					"calibrate":          true,
+					"group":              true,
+					"master":             false,
+					"openDirection":      "left",
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -70,6 +83,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.CurtainDevice{
@@ -94,17 +109,22 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("LockDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ABCDEF123456",
-			"deviceType":         "Smart Lock",
-			"hubDeviceId":        "123456789",
-			"deviceName":         "LockDevice",
-			"enableCloudService": true,
-			"group":              true,
-			"master":             false,
-			"groupName":          "LockGroup",
-			"lockDevicesIds":     []string{"AAAAAAAA"},
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Smart Lock",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "LockDevice",
+					"enableCloudService": true,
+					"group":              true,
+					"master":             false,
+					"groupName":          "LockGroup",
+					"lockDevicesIds":     []string{"AAAAAAAA"},
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -114,6 +134,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.LockDevice{
@@ -137,34 +159,39 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("KeypadDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ABCDEF123456",
-			"deviceType":         "Keypad Touch",
-			"hubDeviceId":        "123456789",
-			"deviceName":         "KeypadDevice",
-			"enableCloudService": true,
-			"lockDevicesIds":     []string{},
-			"keyList": []map[string]interface{}{
-				{
-					"id":         1,
-					"name":       "firstKey",
-					"type":       "permanent",
-					"password":   "z41UoV93PIS0OYElzUd7nwA9TO6XxSDlf9N+P4nFuJw=",
-					"iv":         "71fbf00383b6e214dc08b8b94183cf30",
-					"status":     "normal",
-					"createTime": 1744814218,
-				},
-				{
-					"id":         2,
-					"name":       "secondKey",
-					"type":       "timeLimit",
-					"password":   "z6aSgCwa4+0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5afa=",
-					"iv":         "af0b1a2c3d4e5f6g7h8i9j0k1l2m3n4o5",
-					"status":     "expired",
-					"createTime": 1746025200,
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Keypad Touch",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "KeypadDevice",
+					"enableCloudService": true,
+					"lockDevicesIds":     []string{},
+					"keyList": []map[string]interface{}{
+						{
+							"id":         1,
+							"name":       "firstKey",
+							"type":       "permanent",
+							"password":   "z41UoV93PIS0OYElzUd7nwA9TO6XxSDlf9N+P4nFuJw=",
+							"iv":         "71fbf00383b6e214dc08b8b94183cf30",
+							"status":     "normal",
+							"createTime": 1744814218,
+						},
+						{
+							"id":         2,
+							"name":       "secondKey",
+							"type":       "timeLimit",
+							"password":   "z6aSgCwa4+0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5afa=",
+							"iv":         "af0b1a2c3d4e5f6g7h8i9j0k1l2m3n4o5",
+							"status":     "expired",
+							"createTime": 1746025200,
+						},
+					},
 				},
 			},
-		})
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -174,6 +201,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.KeypadDevice{
@@ -214,20 +243,25 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("BlindTiltDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":            "XYZ123456789",
-			"deviceType":          "Blind Tilt",
-			"hubDeviceId":         "987654321",
-			"deviceName":          "BlindTiltDevice",
-			"enableCloudService":  true,
-			"version":             1,
-			"blindTiltDevicesIds": []string{"BBBBBBBB"},
-			"calibrate":           true,
-			"group":               true,
-			"master":              false,
-			"direction":           "up",
-			"slidePosition":       50,
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":            "XYZ123456789",
+					"deviceType":          "Blind Tilt",
+					"hubDeviceId":         "987654321",
+					"deviceName":          "BlindTiltDevice",
+					"enableCloudService":  true,
+					"version":             1,
+					"blindTiltDevicesIds": []string{"BBBBBBBB"},
+					"calibrate":           true,
+					"group":               true,
+					"master":              false,
+					"direction":           "up",
+					"slidePosition":       50,
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -237,6 +271,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.BlindTiltDevice{
@@ -263,18 +299,23 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("RollerShadeDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ROLLER123456",
-			"deviceType":         "Roller Shade",
-			"hubDeviceId":        "HUB123456",
-			"deviceName":         "RollerShadeDevice",
-			"enableCloudService": true,
-			"bleVersion":         "1.0",
-			"groupingDevicesIds": []string{"GROUP123"},
-			"group":              true,
-			"master":             true,
-			"groupName":          "RollerGroup",
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ROLLER123456",
+					"deviceType":         "Roller Shade",
+					"hubDeviceId":        "HUB123456",
+					"deviceName":         "RollerShadeDevice",
+					"enableCloudService": true,
+					"bleVersion":         "1.0",
+					"groupingDevicesIds": []string{"GROUP123"},
+					"group":              true,
+					"master":             true,
+					"groupName":          "RollerGroup",
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
@@ -284,6 +325,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.RollerShadeDevice{
@@ -308,20 +351,25 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 	t.Run("TwoDevices", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "ABCDEF123456",
-			"deviceType":         "Hub 2",
-			"hubDeviceId":        "123456789",
-			"deviceName":         "Hub2Device",
-			"enableCloudService": true,
-		})
-		switchBotMock.AddDevice(map[string]interface{}{
-			"deviceId":           "GHIJKL987654",
-			"deviceType":         "MeterPro(CO2)",
-			"hubDeviceId":        "987654321",
-			"deviceName":         "MeterProCO2Device",
-			"enableCloudService": true,
-		})
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Hub 2",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "Hub2Device",
+					"enableCloudService": true,
+				},
+				map[string]interface{}{
+					"deviceId":           "GHIJKL987654",
+					"deviceType":         "MeterPro(CO2)",
+					"hubDeviceId":        "987654321",
+					"deviceName":         "MeterProCO2Device",
+					"enableCloudService": true,
+				},
+			},
+			[]interface{}{},
+		)
 		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -330,6 +378,8 @@ func TestGetPhysicalDevices(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
 
 		assertDevices(t, response, []interface{}{
 			&switchbot.Hub2Device{
@@ -363,24 +413,29 @@ func TestGetPhysicalDevices(t *testing.T) {
 
 func TestGetInfraredRemoteDevices(t *testing.T) {
 	switchBotMock := helpers.NewSwitchBotMock(t)
-	switchBotMock.AddInfraredDevice(map[string]interface{}{
-		"deviceId":    "AIRCONDITIONER123456",
-		"deviceName":  "AirConditionerDevice",
-		"remoteType":  "Air Conditioner",
-		"hubDeviceId": "HUB123456",
-	})
-	switchBotMock.AddInfraredDevice(map[string]interface{}{
-		"deviceId":    "SETTOPBOX123456",
-		"deviceName":  "SetTopBoxDevice",
-		"remoteType":  "Set Top Box",
-		"hubDeviceId": "HUB123456",
-	})
-	switchBotMock.AddInfraredDevice(map[string]interface{}{
-		"deviceId":    "OTHERDEVICE123456",
-		"deviceName":  "OthersDevice",
-		"remoteType":  "Others",
-		"hubDeviceId": "HUB123456",
-	})
+	switchBotMock.RegisterDevicesMock(
+		[]interface{}{},
+		[]interface{}{
+			map[string]interface{}{
+				"deviceId":    "AIRCONDITIONER123456",
+				"deviceName":  "AirConditionerDevice",
+				"remoteType":  "Air Conditioner",
+				"hubDeviceId": "HUB123456",
+			},
+			map[string]interface{}{
+				"deviceId":    "SETTOPBOX123456",
+				"deviceName":  "SetTopBoxDevice",
+				"remoteType":  "Set Top Box",
+				"hubDeviceId": "HUB123456",
+			},
+			map[string]interface{}{
+				"deviceId":    "OTHERDEVICE123456",
+				"deviceName":  "OthersDevice",
+				"remoteType":  "Others",
+				"hubDeviceId": "HUB123456",
+			},
+		},
+	)
 	testServer := switchBotMock.NewTestServer()
 
 	client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))

--- a/device_test.go
+++ b/device_test.go
@@ -2,39 +2,26 @@ package switchbot_test
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/yasu89/switch-bot-api-go"
+	"github.com/yasu89/switch-bot-api-go/helpers"
 )
 
 func TestGetPhysicalDevices(t *testing.T) {
 	// Tests do not cover devices that only embed CommonDeviceListItem/InfraredRemoteDevice with the same structure.
 
 	t.Run("BotDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "ABCDEF123456",
-                "deviceType": "Bot",
-                "hubDeviceId": "123456789",
-                "deviceName": "BotDevice",
-                "enableCloudService": true
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ABCDEF123456",
+			"deviceType":         "Bot",
+			"hubDeviceId":        "123456789",
+			"deviceName":         "BotDevice",
+			"enableCloudService": true,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -61,32 +48,20 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("CurtainDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "ABCDEF123456",
-                "deviceType": "Curtain3",
-                "hubDeviceId": "123456789",
-                "deviceName": "CurtainDevice",
-                "enableCloudService": false,
-				"curtainDevicesIds": ["BBBBBBBB", "CCCCCCCC", "DDDDDDDD"],
-				"calibrate": true,
-				"group": true,
-				"master": false,
-				"openDirection": "left"
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ABCDEF123456",
+			"deviceType":         "Curtain3",
+			"hubDeviceId":        "123456789",
+			"deviceName":         "CurtainDevice",
+			"enableCloudService": false,
+			"curtainDevicesIds":  []string{"BBBBBBBB", "CCCCCCCC", "DDDDDDDD"},
+			"calibrate":          true,
+			"group":              true,
+			"master":             false,
+			"openDirection":      "left",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -118,31 +93,19 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("LockDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "ABCDEF123456",
-                "deviceType": "Smart Lock",
-                "hubDeviceId": "123456789",
-                "deviceName": "LockDevice",
-                "enableCloudService": true,
-				"group": true,
-				"master": false,
-				"groupName": "LockGroup",
-				"lockDevicesIds": ["AAAAAAAA"]
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ABCDEF123456",
+			"deviceType":         "Smart Lock",
+			"hubDeviceId":        "123456789",
+			"deviceName":         "LockDevice",
+			"enableCloudService": true,
+			"group":              true,
+			"master":             false,
+			"groupName":          "LockGroup",
+			"lockDevicesIds":     []string{"AAAAAAAA"},
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -173,48 +136,36 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("KeypadDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "ABCDEF123456",
-                "deviceType": "Keypad Touch",
-                "hubDeviceId": "123456789",
-                "deviceName": "KeypadDevice",
-                "enableCloudService": true,
-				"lockDevicesIds": [],
-				"keyList": [
-					{
-						"id": 1,
-						"name": "firstKey",
-						"type": "permanent",
-						"password": "z41UoV93PIS0OYElzUd7nwA9TO6XxSDlf9N+P4nFuJw=",
-						"iv": "71fbf00383b6e214dc08b8b94183cf30",
-						"status": "normal",
-						"createTime": 1744814218
-					},
-					{
-						"id": 2,
-						"name": "secondKey",
-						"type": "timeLimit",
-						"password": "z6aSgCwa4+0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5afa=",
-						"iv": "af0b1a2c3d4e5f6g7h8i9j0k1l2m3n4o5",
-						"status": "expired",
-						"createTime": 1746025200
-					}
-				]
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ABCDEF123456",
+			"deviceType":         "Keypad Touch",
+			"hubDeviceId":        "123456789",
+			"deviceName":         "KeypadDevice",
+			"enableCloudService": true,
+			"lockDevicesIds":     []string{},
+			"keyList": []map[string]interface{}{
+				{
+					"id":         1,
+					"name":       "firstKey",
+					"type":       "permanent",
+					"password":   "z41UoV93PIS0OYElzUd7nwA9TO6XxSDlf9N+P4nFuJw=",
+					"iv":         "71fbf00383b6e214dc08b8b94183cf30",
+					"status":     "normal",
+					"createTime": 1744814218,
+				},
+				{
+					"id":         2,
+					"name":       "secondKey",
+					"type":       "timeLimit",
+					"password":   "z6aSgCwa4+0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5afa=",
+					"iv":         "af0b1a2c3d4e5f6g7h8i9j0k1l2m3n4o5",
+					"status":     "expired",
+					"createTime": 1746025200,
+				},
+			},
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -262,34 +213,22 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("BlindTiltDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "XYZ123456789",
-                "deviceType": "Blind Tilt",
-                "hubDeviceId": "987654321",
-                "deviceName": "BlindTiltDevice",
-                "enableCloudService": true,
-                "version": 1,
-                "blindTiltDevicesIds": ["BBBBBBBB"],
-                "calibrate": true,
-                "group": true,
-                "master": false,
-                "direction": "up",
-                "slidePosition": 50
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":            "XYZ123456789",
+			"deviceType":          "Blind Tilt",
+			"hubDeviceId":         "987654321",
+			"deviceName":          "BlindTiltDevice",
+			"enableCloudService":  true,
+			"version":             1,
+			"blindTiltDevicesIds": []string{"BBBBBBBB"},
+			"calibrate":           true,
+			"group":               true,
+			"master":              false,
+			"direction":           "up",
+			"slidePosition":       50,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -323,32 +262,20 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("RollerShadeDevice", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-	   "statusCode": 100,
-	   "body": {
-	       "deviceList": [
-	           {
-	               "deviceId": "ROLLER123456",
-	               "deviceType": "Roller Shade",
-	               "hubDeviceId": "HUB123456",
-	               "deviceName": "RollerShadeDevice",
-	               "enableCloudService": true,
-	               "bleVersion": "1.0",
-	               "groupingDevicesIds": ["GROUP123"],
-	               "group": true,
-	               "master": true,
-	               "groupName": "RollerGroup"
-				}
-	       ],
-	       "infraredRemoteList": []
-	   },
-	   "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ROLLER123456",
+			"deviceType":         "Roller Shade",
+			"hubDeviceId":        "HUB123456",
+			"deviceName":         "RollerShadeDevice",
+			"enableCloudService": true,
+			"bleVersion":         "1.0",
+			"groupingDevicesIds": []string{"GROUP123"},
+			"group":              true,
+			"master":             true,
+			"groupName":          "RollerGroup",
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
@@ -380,36 +307,23 @@ func TestGetPhysicalDevices(t *testing.T) {
 	})
 
 	t.Run("TwoDevices", func(t *testing.T) {
-		testServer := httptest.NewServer(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
-    "statusCode": 100,
-    "body": {
-        "deviceList": [
-            {
-                "deviceId": "ABCDEF123456",
-                "deviceType": "Hub 2",
-                "hubDeviceId": "123456789",
-                "deviceName": "Hub2Device",
-                "enableCloudService": true
-            },
-			{
-                "deviceId": "GHIJKL987654",
-                "deviceType": "MeterPro(CO2)",
-                "hubDeviceId": "987654321",
-                "deviceName": "MeterProCO2Device",
-                "enableCloudService": true
-            }
-        ],
-        "infraredRemoteList": []
-    },
-    "message": "success"
-}`))
-			}),
-		)
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "ABCDEF123456",
+			"deviceType":         "Hub 2",
+			"hubDeviceId":        "123456789",
+			"deviceName":         "Hub2Device",
+			"enableCloudService": true,
+		})
+		switchBotMock.AddDevice(map[string]interface{}{
+			"deviceId":           "GHIJKL987654",
+			"deviceType":         "MeterPro(CO2)",
+			"hubDeviceId":        "987654321",
+			"deviceName":         "MeterProCO2Device",
+			"enableCloudService": true,
+		})
+		testServer := switchBotMock.NewTestServer()
 		defer testServer.Close()
-
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
 
 		response, err := client.GetDevices()
@@ -448,39 +362,26 @@ func TestGetPhysicalDevices(t *testing.T) {
 }
 
 func TestGetInfraredRemoteDevices(t *testing.T) {
-	testServer := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
-	"statusCode": 100,
-	"body": {
-		"deviceList": [],
-		"infraredRemoteList": [
-			{
-				"deviceId": "AIRCONDITIONER123456",
-				"deviceName": "AirConditionerDevice",
-				"remoteType": "Air Conditioner",
-				"hubDeviceId": "HUB123456"
-			},
-			{
-				"deviceId": "SETTOPBOX123456",
-				"deviceName": "SetTopBoxDevice",
-				"remoteType": "Set Top Box",
-				"hubDeviceId": "HUB123456"
-			},
-			{
-				"deviceId": "OTHERDEVICE123456",
-				"deviceName": "OthersDevice",
-				"remoteType": "Others",
-				"hubDeviceId": "HUB123456"
-			}
-		]
-	},
-	"message": "success"
-}`))
-		}),
-	)
-	defer testServer.Close()
+	switchBotMock := helpers.NewSwitchBotMock(t)
+	switchBotMock.AddInfraredDevice(map[string]interface{}{
+		"deviceId":    "AIRCONDITIONER123456",
+		"deviceName":  "AirConditionerDevice",
+		"remoteType":  "Air Conditioner",
+		"hubDeviceId": "HUB123456",
+	})
+	switchBotMock.AddInfraredDevice(map[string]interface{}{
+		"deviceId":    "SETTOPBOX123456",
+		"deviceName":  "SetTopBoxDevice",
+		"remoteType":  "Set Top Box",
+		"hubDeviceId": "HUB123456",
+	})
+	switchBotMock.AddInfraredDevice(map[string]interface{}{
+		"deviceId":    "OTHERDEVICE123456",
+		"deviceName":  "OthersDevice",
+		"remoteType":  "Others",
+		"hubDeviceId": "HUB123456",
+	})
+	testServer := switchBotMock.NewTestServer()
 
 	client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
 

--- a/helpers/mock.go
+++ b/helpers/mock.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yasu89/switch-bot-api-go"
+)
+
+type SwitchBotMock struct {
+	t               *testing.T
+	devices         []interface{}
+	infraredDevices []interface{}
+	handlers        map[string]interface{}
+}
+
+func NewSwitchBotMock(t *testing.T) *SwitchBotMock {
+	return &SwitchBotMock{
+		t: t,
+	}
+}
+
+// AddDevice adds a device to the mock server's response.
+func (s *SwitchBotMock) AddDevice(device interface{}) {
+	s.devices = append(s.devices, device)
+}
+
+// AddInfraredDevice adds an infrared device to the mock server's response.
+func (s *SwitchBotMock) AddInfraredDevice(device interface{}) {
+	s.infraredDevices = append(s.infraredDevices, device)
+}
+
+func (s *SwitchBotMock) NewTestServer() *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/devices" {
+				if r.Method != http.MethodGet {
+					s.t.Fatalf("/devices API expected GET request, got %s", r.Method)
+				}
+
+				response := switchbot.GetDevicesResponse{
+					CommonResponse: switchbot.CommonResponse{
+						StatusCode: 100,
+						Message:    "success",
+					},
+					Body: switchbot.GetDevicesResponseBody{
+						DeviceList:         s.devices,
+						InfraredRemoteList: s.infraredDevices,
+					},
+				}
+				responseJsonText, err := json.Marshal(response)
+				if err != nil {
+					s.t.Fatalf("Failed to marshal response: %v", err)
+				}
+
+				w.WriteHeader(http.StatusOK)
+				w.Header().Set("Content-Type", "application/json")
+				_, err = w.Write(responseJsonText)
+				if err != nil {
+					s.t.Fatalf("Failed to write response: %v", err)
+				}
+			}
+		}),
+	)
+}

--- a/helpers/mock.go
+++ b/helpers/mock.go
@@ -9,11 +9,31 @@ import (
 	"github.com/yasu89/switch-bot-api-go"
 )
 
+type HttpMockHandler struct {
+	Method  string
+	Path    string
+	Count   int
+	Handler http.HandlerFunc
+}
+
+// IsMatch checks if the method and path match the handler's method and path.
+func (h *HttpMockHandler) IsMatch(method string, path string) bool {
+	if method != h.Method {
+		return false
+	}
+
+	if path != h.Path {
+		return false
+	}
+
+	return true
+}
+
 type SwitchBotMock struct {
 	t               *testing.T
 	devices         []interface{}
 	infraredDevices []interface{}
-	handlers        map[string]interface{}
+	handlers        []*HttpMockHandler
 }
 
 func NewSwitchBotMock(t *testing.T) *SwitchBotMock {
@@ -32,6 +52,51 @@ func (s *SwitchBotMock) AddInfraredDevice(device interface{}) {
 	s.infraredDevices = append(s.infraredDevices, device)
 }
 
+// RegisterStatusMock registers a mock response for a specific device's status.
+func (s *SwitchBotMock) RegisterStatusMock(deviceId string, mockBody interface{}) {
+	s.handlers = append(s.handlers, &HttpMockHandler{
+		Method: http.MethodGet,
+		Path:   "/devices/" + deviceId + "/status",
+		Count:  0,
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			response := struct {
+				switchbot.CommonResponse
+				Body interface{} `json:"body"`
+			}{
+				CommonResponse: switchbot.CommonResponse{
+					StatusCode: 100,
+					Message:    "success",
+				},
+				Body: mockBody,
+			}
+			responseJsonText, err := json.Marshal(response)
+			if err != nil {
+				s.t.Fatalf("Failed to marshal response: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write(responseJsonText)
+			if err != nil {
+				s.t.Fatalf("Failed to write response: %v", err)
+			}
+		},
+	})
+}
+
+// AssertCallCount checks the number of times a specific method and path were called.
+func (s *SwitchBotMock) AssertCallCount(method string, path string, expected int) {
+	for _, handler := range s.handlers {
+		if handler.IsMatch(method, path) {
+			if handler.Count != expected {
+				s.t.Fatalf("Expected %d calls to %s %s, got %d", expected, method, path, handler.Count)
+			}
+			return
+		}
+	}
+	s.t.Fatalf("No handler found for %s %s", method, path)
+}
+
+// NewTestServer creates a new test server with the mock handlers.
 func (s *SwitchBotMock) NewTestServer() *httptest.Server {
 	return httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +126,17 @@ func (s *SwitchBotMock) NewTestServer() *httptest.Server {
 				if err != nil {
 					s.t.Fatalf("Failed to write response: %v", err)
 				}
+				return
+			} else {
+				for _, handler := range s.handlers {
+					if handler.IsMatch(r.Method, r.URL.Path) {
+						handler.Count++
+						handler.Handler(w, r)
+						return
+					}
+				}
 			}
+			s.t.Fatalf("No handler found for %s %s", r.Method, r.URL.Path)
 		}),
 	)
 }

--- a/helpers/mock.go
+++ b/helpers/mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yasu89/switch-bot-api-go"
 )
 
+// HttpMockHandler is a struct that represents a mock HTTP handler.
 type HttpMockHandler struct {
 	Method  string
 	Path    string
@@ -29,27 +30,48 @@ func (h *HttpMockHandler) IsMatch(method string, path string) bool {
 	return true
 }
 
+// SwitchBotMock is a mock for the SwitchBot API.
 type SwitchBotMock struct {
-	t               *testing.T
-	devices         []interface{}
-	infraredDevices []interface{}
-	handlers        []*HttpMockHandler
+	t        *testing.T
+	handlers []*HttpMockHandler
 }
 
+// NewSwitchBotMock creates a new instance of SwitchBotMock.
 func NewSwitchBotMock(t *testing.T) *SwitchBotMock {
 	return &SwitchBotMock{
 		t: t,
 	}
 }
 
-// AddDevice adds a device to the mock server's response.
-func (s *SwitchBotMock) AddDevice(device interface{}) {
-	s.devices = append(s.devices, device)
-}
-
-// AddInfraredDevice adds an infrared device to the mock server's response.
-func (s *SwitchBotMock) AddInfraredDevice(device interface{}) {
-	s.infraredDevices = append(s.infraredDevices, device)
+// RegisterDevicesMock registers a mock response for the device's endpoint.
+func (s *SwitchBotMock) RegisterDevicesMock(devices []interface{}, infraredDevices []interface{}) {
+	s.handlers = append(s.handlers, &HttpMockHandler{
+		Method: http.MethodGet,
+		Path:   "/devices",
+		Count:  0,
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			response := switchbot.GetDevicesResponse{
+				CommonResponse: switchbot.CommonResponse{
+					StatusCode: 100,
+					Message:    "success",
+				},
+				Body: switchbot.GetDevicesResponseBody{
+					DeviceList:         devices,
+					InfraredRemoteList: infraredDevices,
+				},
+			}
+			responseJsonText, err := json.Marshal(response)
+			if err != nil {
+				s.t.Fatalf("Failed to marshal response: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_, err = w.Write(responseJsonText)
+			if err != nil {
+				s.t.Fatalf("Failed to write response: %v", err)
+			}
+		},
+	})
 }
 
 // RegisterStatusMock registers a mock response for a specific device's status.
@@ -100,40 +122,11 @@ func (s *SwitchBotMock) AssertCallCount(method string, path string, expected int
 func (s *SwitchBotMock) NewTestServer() *httptest.Server {
 	return httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/devices" {
-				if r.Method != http.MethodGet {
-					s.t.Fatalf("/devices API expected GET request, got %s", r.Method)
-				}
-
-				response := switchbot.GetDevicesResponse{
-					CommonResponse: switchbot.CommonResponse{
-						StatusCode: 100,
-						Message:    "success",
-					},
-					Body: switchbot.GetDevicesResponseBody{
-						DeviceList:         s.devices,
-						InfraredRemoteList: s.infraredDevices,
-					},
-				}
-				responseJsonText, err := json.Marshal(response)
-				if err != nil {
-					s.t.Fatalf("Failed to marshal response: %v", err)
-				}
-
-				w.WriteHeader(http.StatusOK)
-				w.Header().Set("Content-Type", "application/json")
-				_, err = w.Write(responseJsonText)
-				if err != nil {
-					s.t.Fatalf("Failed to write response: %v", err)
-				}
-				return
-			} else {
-				for _, handler := range s.handlers {
-					if handler.IsMatch(r.Method, r.URL.Path) {
-						handler.Count++
-						handler.Handler(w, r)
-						return
-					}
+			for _, handler := range s.handlers {
+				if handler.IsMatch(r.Method, r.URL.Path) {
+					handler.Count++
+					handler.Handler(w, r)
+					return
 				}
 			}
 			s.t.Fatalf("No handler found for %s %s", r.Method, r.URL.Path)


### PR DESCRIPTION
This pull request refactors the test suite in `device_control_test.go` to use a new `SwitchBotMock` helper for mocking API calls, replacing the previous `newTestCommandServer` function. This improves test readability and ensures consistent validation of API call counts. Additionally, it introduces assertions to verify the number of API calls made during each test.

### Refactoring to use `SwitchBotMock`:

* Replaced `newTestCommandServer` with `helpers.NewSwitchBotMock` in all test cases, simplifying the setup of mock servers. (`device_control_test.go`: [[1]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L38-R38) [[2]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L91-R94) [[3]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L151-R157) [[4]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L192-R201) [[5]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L252-R264) [[6]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L297-R312) [[7]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L349-R367) [[8]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L387-R408) [[9]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L454-R478) [[10]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L499-R526) [[11]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L544-R574) [[12]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L596-R629) [[13]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L641-R677) [[14]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L693-R732) [[15]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L745-R787) [[16]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L783-R828) [[17]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69L828-R876)

### Adding API call count assertions:

* Introduced `switchBotMock.AssertCallCount` to verify the number of POST requests made to `/devices/{deviceId}/commands` in each test case, ensuring accurate API interaction. (`device_control_test.go`: [[1]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R55) [[2]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R111) [[3]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R174) [[4]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R218) [[5]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R281) [[6]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R329) [[7]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R384) [[8]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R425) [[9]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R495) [[10]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R543) [[11]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R591) [[12]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R646) [[13]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R694) [[14]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R749) [[15]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R804) [[16]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R845) [[17]](diffhunk://#diff-0cacee72dae9b6446eed3ecc1f895a7a621469b667555120a31b61c678d13c69R893)