### PR TITLE
add tagpr actions

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,16 @@
+name: tagpr
+on:
+  push:
+    branches: ["main"]
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: Songmu/tagpr@35daec35e8e3172806c763d8f196e6434fd44fbd # v1.5.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate tagging and release processes. The workflow is triggered on pushes to the `main` branch and uses the `tagpr` action to manage tags and pull requests.

### New GitHub Actions Workflow:

* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR1-R16): Added a `tagpr` workflow that runs on the `main` branch. It uses the `actions/checkout` action and the `Songmu/tagpr` action to automate tagging and release management. The workflow is configured with necessary permissions (`contents`, `pull-requests`, and `issues`) and utilizes the `GITHUB_TOKEN` secret for authentication.