### PR TITLE
Update tagpr.yml to use GitHub App token for authentication

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -10,7 +10,14 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+    - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+      id: app-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
     - uses: Songmu/tagpr@35daec35e8e3172806c763d8f196e6434fd44fbd # v1.5.2
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/tagpr.yml` to enhance security and ensure proper authentication by switching from a repository-scoped `GITHUB_TOKEN` to a GitHub App token.

### Workflow updates for authentication:

* Added the `actions/create-github-app-token` action to generate a GitHub App token using the provided `APP_ID` and `PRIVATE_KEY`. This replaces the default `GITHUB_TOKEN` for subsequent steps.
* Updated the `actions/checkout` step to use the GitHub App token for authentication.
* Updated the `Songmu/tagpr` step to use the generated GitHub App token instead of the default `GITHUB_TOKEN` for improved security.