### PR TITLE
Add GitHub Actions workflow for gocredits automation

### DIFF
--- a/.github/workflows/gocredits.yml
+++ b/.github/workflows/gocredits.yml
@@ -1,0 +1,20 @@
+name: gocredits
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  gocredits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      id: setup-go
+      with:
+        go-version-file: go.mod
+    - name: Install dependencies
+      run: go mod tidy
+    - uses: yasu89/gocredits-action@de0d1b0dbcf41cbb27ef205029e65454045790ee # v1.0.0


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the generation of Go module credits using the `gocredits` tool.

### New GitHub Actions Workflow:

* [`.github/workflows/gocredits.yml`](diffhunk://#diff-a363868b7329a031d6b5801f8a9f81613ee2f1593bfdd82ce5257d810f74ae30R1-R20): Added a `gocredits` workflow that triggers on pushes to the `main` branch and on pull requests. The workflow sets up a Go environment, installs dependencies, and runs the `gocredits-action` to generate module credits.