### PR TITLE
Add Support for New SwitchBot Devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,22 @@ This is a Go library for the SwitchBot API v1.1 that provides type-safe access t
 - **Dynamic Type Resolution**: The `GetDevicesResponseParser` dynamically creates appropriate device structs based on `deviceType` and `remoteType` fields
 - **Client Injection**: All device structs contain a `*Client` field for API operations
 - **Response Parsing**: Custom response parsers handle the complex JSON unmarshaling for different device types
+- **Shared Device Support**: Some devices with identical functionality share the same struct (e.g., Lock Ultra uses LockDevice, S10/S20 robots use RobotVacuumCleanerSDevice)
+
+### Implementation Guidelines
+
+**API Documentation Compliance**:
+- **ALWAYS** refer to the official SwitchBot API documentation at https://raw.githubusercontent.com/OpenWonderLabs/SwitchBotAPI/main/README.md when implementing new device support
+- Device status fields, command parameters, and data types must match the official API specification exactly
+- When adding new devices, verify the device type strings and supported operations from the official documentation
+- Status response structures should reflect the exact JSON schema provided in the API docs
+
+**Device Implementation Process**:
+1. Check the official API documentation for device specifications
+2. Verify device type strings and available commands
+3. Implement status structures with correct field names and data types
+4. Add device to the parser with the exact `deviceType` string from the API
+5. Update README.md and README_ja.md to reflect support status
 
 ### Authentication
 The library uses SwitchBot API v1.1 authentication requiring:

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Relay Switch 1                        |         ✅         |     ✅      |      ✅       |              |
 | Relay Switch 2PM                      |         ✅         |     ✅      |      ✅       |              |
 | Garage Door Opener                    |         ✅         |     ✅      |      ✅       |              |
-| Floor Lamp                            |         ❌         |     ❌      |      ❌       |              |
-| LED Strip Light 3                     |         ❌         |     ❌      |      ❌       |              |
+| Floor Lamp                            |         ✅         |     ✅      |      ✅       |              |
+| LED Strip Light 3                     |         ✅         |     ✅      |      ✅       |              |
 | Lock Lite                             |         ❌         |     ❌      |      ❌       |              |
 | Video Doorbell                        |         ❌         |     ❌      |      ❌       |              |
 | Keypad Vision                         |         ❌         |     ❌      |      ❌       |              |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Mini Robot Vacuum K10+ Pro            |         ✅         |     ✅      |      ✅       |              |
 | K10+ Pro Combo                        |         ✅         |     ✅      |      ✅       |              |
 | Floor Cleaning Robot S10              |         ✅         |     ✅      |      ✅       |              |
-| Floor Cleaning Robot S20              |         ❌         |     ❌      |      ❌       |              |
+| Floor Cleaning Robot S20              |         ✅         |     ✅      |      ✅       |              |
 | Multitasking Household Robot K20+ Pro |         ❌         |     ❌      |      ❌       |              |
 | Humidifier                            |         ✅         |     ✅      |      ✅       |              |
 | Evaporative Humidifier                |         ✅         |     ✅      |      ✅       |              |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Meter Pro CO2                         |         ✅         |     ✅      |      -       |              |
 | Lock                                  |         ✅         |     ✅      |      ✅       |              |
 | Lock Pro                              |         ✅         |     ✅      |      ✅       |              |
-| Lock Ultra                            |         ❌         |     ❌      |      ❌       |              |
+| Lock Ultra                            |         ✅         |     ✅      |      ✅       |              |
 | Keypad                                |         ✅         |     ✅      |      ✅       |              |
 | Keypad Touch                          |         ✅         |     ✅      |      ✅       |              |
 | Remote                                |         ✅         |     -      |      -       |              |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | K10+ Pro Combo                        |         ✅         |     ✅      |      ✅       |              |
 | Floor Cleaning Robot S10              |         ✅         |     ✅      |      ✅       |              |
 | Floor Cleaning Robot S20              |         ✅         |     ✅      |      ✅       |              |
-| Multitasking Household Robot K20+ Pro |         ❌         |     ❌      |      ❌       |              |
+| Multitasking Household Robot K20+ Pro |         ✅         |     ✅      |      ✅       |              |
 | Humidifier                            |         ✅         |     ✅      |      ✅       |              |
 | Evaporative Humidifier                |         ✅         |     ✅      |      ✅       |              |
 | Evaporative Humidifier (Auto-refill)  |         ✅         |     ✅      |      ✅       |              |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Relay Switch 1PM                      |         ✅         |     ✅      |      ✅       |              |
 | Relay Switch 1                        |         ✅         |     ✅      |      ✅       |              |
 | Relay Switch 2PM                      |         ✅         |     ✅      |      ✅       |              |
-| Garage Door Opener                    |         ❌         |     ❌      |      ❌       |              |
+| Garage Door Opener                    |         ✅         |     ✅      |      ✅       |              |
 | Floor Lamp                            |         ❌         |     ❌      |      ❌       |              |
 | LED Strip Light 3                     |         ❌         |     ❌      |      ❌       |              |
 | Lock Lite                             |         ❌         |     ❌      |      ❌       |              |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Floor Lamp                            |         ✅         |     ✅      |      ✅       |              |
 | LED Strip Light 3                     |         ✅         |     ✅      |      ✅       |              |
 | Lock Lite                             |         ✅         |     ✅      |      ✅       |              |
-| Video Doorbell                        |         ❌         |     ❌      |      ❌       |              |
+| Video Doorbell                        |         ✅         |     ✅      |      ✅       |              |
 | Keypad Vision                         |         ❌         |     ❌      |      ❌       |              |
 
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Garage Door Opener                    |         ✅         |     ✅      |      ✅       |              |
 | Floor Lamp                            |         ✅         |     ✅      |      ✅       |              |
 | LED Strip Light 3                     |         ✅         |     ✅      |      ✅       |              |
-| Lock Lite                             |         ❌         |     ❌      |      ❌       |              |
+| Lock Lite                             |         ✅         |     ✅      |      ✅       |              |
 | Video Doorbell                        |         ❌         |     ❌      |      ❌       |              |
 | Keypad Vision                         |         ❌         |     ❌      |      ❌       |              |
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Roller Shade                          |         ✅         |     ✅      |      ✅       |              |
 | Relay Switch 1PM                      |         ✅         |     ✅      |      ✅       |              |
 | Relay Switch 1                        |         ✅         |     ✅      |      ✅       |              |
-| Relay Switch 2PM                      |         ❌         |     ❌      |      ❌       |              |
+| Relay Switch 2PM                      |         ✅         |     ✅      |      ✅       |              |
 | Garage Door Opener                    |         ❌         |     ❌      |      ❌       |              |
 | Floor Lamp                            |         ❌         |     ❌      |      ❌       |              |
 | LED Strip Light 3                     |         ❌         |     ❌      |      ❌       |              |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Hub Plus                              |         ✅         |     -      |      -       |              |
 | Hub Mini                              |         ✅         |     -      |      -       |      ✅       |
 | Hub 2                                 |         ✅         |     ✅      |      -       |      ✅       |
-| Hub 3                                 |         ❌         |     ❌      |      ❌       |              |
+| Hub 3                                 |         ✅         |     ✅      |      -       |              |
 | Meter                                 |         ✅         |     ✅      |      -       |      ✅       |
 | Meter Plus                            |         ✅         |     ✅      |      -       |              |
 | Outdoor Meter                         |         ✅         |     ✅      |      -       |              |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | LED Strip Light 3                     |         ✅         |     ✅      |      ✅       |              |
 | Lock Lite                             |         ✅         |     ✅      |      ✅       |              |
 | Video Doorbell                        |         ✅         |     ✅      |      ✅       |              |
-| Keypad Vision                         |         ❌         |     ❌      |      ❌       |              |
+| Keypad Vision                         |         ✅         |     ✅      |      ✅       |              |
 
 
 ### Virtual Infrared Remote Devices

--- a/README_ja.md
+++ b/README_ja.md
@@ -98,7 +98,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Relay Switch 1PM                      |   ✅   |    ✅    |   ✅    |      |
 | Relay Switch 1                        |   ✅   |    ✅    |   ✅    |      |
 | Relay Switch 2PM                      |   ✅   |    ✅    |   ✅    |      |
-| Garage Door Opener                    |   ❌   |    ❌    |   ❌    |      |
+| Garage Door Opener                    |   ✅   |    ✅    |   ✅    |      |
 | Floor Lamp                            |   ❌   |    ❌    |   ❌    |      |
 | LED Strip Light 3                     |   ❌   |    ❌    |   ❌    |      |
 | Lock Lite                             |   ❌   |    ❌    |   ❌    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,7 +51,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Hub Plus                              |   ✅   |    -    |   -    |      |
 | Hub Mini                              |   ✅   |    -    |   -    |  ✅   |
 | Hub 2                                 |   ✅   |    ✅    |   -    |  ✅   |
-| Hub 3                                 |   ❌   |    ❌    |   ❌    |      |
+| Hub 3                                 |   ✅   |    ✅    |   -    |      |
 | Meter                                 |   ✅   |    ✅    |   -    |  ✅   |
 | Meter Plus                            |   ✅   |    ✅    |   -    |      |
 | Outdoor Meter                         |   ✅   |    ✅    |   -    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -80,7 +80,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | K10+ Pro Combo                        |   ✅   |    ✅    |   ✅    |      |
 | Floor Cleaning Robot S10              |   ✅   |    ✅    |   ✅    |      |
 | Floor Cleaning Robot S20              |   ✅   |    ✅    |   ✅    |      |
-| Multitasking Household Robot K20+ Pro |   ❌   |    ❌    |   ❌    |      |
+| Multitasking Household Robot K20+ Pro |   ✅   |    ✅    |   ✅    |      |
 | Humidifier                            |   ✅   |    ✅    |   ✅    |      |
 | Evaporative Humidifier                |   ✅   |    ✅    |   ✅    |      |
 | Evaporative Humidifier (Auto-refill)  |   ✅   |    ✅    |   ✅    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -97,7 +97,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Roller Shade                          |   ✅   |    ✅    |   ✅    |      |
 | Relay Switch 1PM                      |   ✅   |    ✅    |   ✅    |      |
 | Relay Switch 1                        |   ✅   |    ✅    |   ✅    |      |
-| Relay Switch 2PM                      |   ❌   |    ❌    |   ❌    |      |
+| Relay Switch 2PM                      |   ✅   |    ✅    |   ✅    |      |
 | Garage Door Opener                    |   ❌   |    ❌    |   ❌    |      |
 | Floor Lamp                            |   ❌   |    ❌    |   ❌    |      |
 | LED Strip Light 3                     |   ❌   |    ❌    |   ❌    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -101,7 +101,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Garage Door Opener                    |   ✅   |    ✅    |   ✅    |      |
 | Floor Lamp                            |   ✅   |    ✅    |   ✅    |      |
 | LED Strip Light 3                     |   ✅   |    ✅    |   ✅    |      |
-| Lock Lite                             |   ❌   |    ❌    |   ❌    |      |
+| Lock Lite                             |   ✅   |    ✅    |   ✅    |      |
 | Video Doorbell                        |   ❌   |    ❌    |   ❌    |      |
 | Keypad Vision                         |   ❌   |    ❌    |   ❌    |      |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,7 +59,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Meter Pro CO2                         |   ✅   |    ✅    |   -    |      |
 | Lock                                  |   ✅   |    ✅    |   ✅    |      |
 | Lock Pro                              |   ✅   |    ✅    |   ✅    |      |
-| Lock Ultra                            |   ❌   |    ❌    |   ❌    |      |
+| Lock Ultra                            |   ✅   |    ✅    |   ✅    |      |
 | Keypad                                |   ✅   |    ✅    |   ✅    |      |
 | Keypad Touch                          |   ✅   |    ✅    |   ✅    |      |
 | Remote                                |   ✅   |    -    |   -    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -103,7 +103,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | LED Strip Light 3                     |   ✅   |    ✅    |   ✅    |      |
 | Lock Lite                             |   ✅   |    ✅    |   ✅    |      |
 | Video Doorbell                        |   ✅   |    ✅    |   ✅    |      |
-| Keypad Vision                         |   ❌   |    ❌    |   ❌    |      |
+| Keypad Vision                         |   ✅   |    ✅    |   ✅    |      |
 
 ### 赤外線リモコン
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -99,8 +99,8 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Relay Switch 1                        |   ✅   |    ✅    |   ✅    |      |
 | Relay Switch 2PM                      |   ✅   |    ✅    |   ✅    |      |
 | Garage Door Opener                    |   ✅   |    ✅    |   ✅    |      |
-| Floor Lamp                            |   ❌   |    ❌    |   ❌    |      |
-| LED Strip Light 3                     |   ❌   |    ❌    |   ❌    |      |
+| Floor Lamp                            |   ✅   |    ✅    |   ✅    |      |
+| LED Strip Light 3                     |   ✅   |    ✅    |   ✅    |      |
 | Lock Lite                             |   ❌   |    ❌    |   ❌    |      |
 | Video Doorbell                        |   ❌   |    ❌    |   ❌    |      |
 | Keypad Vision                         |   ❌   |    ❌    |   ❌    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,7 +79,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Mini Robot Vacuum K10+ Pro            |   ✅   |    ✅    |   ✅    |      |
 | K10+ Pro Combo                        |   ✅   |    ✅    |   ✅    |      |
 | Floor Cleaning Robot S10              |   ✅   |    ✅    |   ✅    |      |
-| Floor Cleaning Robot S20              |   ❌   |    ❌    |   ❌    |      |
+| Floor Cleaning Robot S20              |   ✅   |    ✅    |   ✅    |      |
 | Multitasking Household Robot K20+ Pro |   ❌   |    ❌    |   ❌    |      |
 | Humidifier                            |   ✅   |    ✅    |   ✅    |      |
 | Evaporative Humidifier                |   ✅   |    ✅    |   ✅    |      |

--- a/README_ja.md
+++ b/README_ja.md
@@ -102,7 +102,7 @@ $ go get github.com/yasu89/switch-bot-api-go
 | Floor Lamp                            |   ✅   |    ✅    |   ✅    |      |
 | LED Strip Light 3                     |   ✅   |    ✅    |   ✅    |      |
 | Lock Lite                             |   ✅   |    ✅    |   ✅    |      |
-| Video Doorbell                        |   ❌   |    ❌    |   ❌    |      |
+| Video Doorbell                        |   ✅   |    ✅    |   ✅    |      |
 | Keypad Vision                         |   ❌   |    ❌    |   ❌    |      |
 
 ### 赤外線リモコン

--- a/device.go
+++ b/device.go
@@ -215,6 +215,11 @@ type GarageDoorOpenerDevice struct {
 	CommonDeviceListItem
 }
 
+// VideoDoorbellDevice represents a SwitchBot Video Doorbell device
+type VideoDoorbellDevice struct {
+	CommonDeviceListItem
+}
+
 type InfraredRemoteDevice struct {
 	Client      *Client
 	DeviceID    string `json:"deviceId"`
@@ -433,6 +438,9 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Relay Switch 2PM":
 				parsed = &RelaySwitch2PMDevice{}
 				parsed.(*RelaySwitch2PMDevice).Client = client
+			case "Video Doorbell":
+				parsed = &VideoDoorbellDevice{}
+				parsed.(*VideoDoorbellDevice).Client = client
 			default:
 				parsed = &CommonDeviceListItem{}
 				parsed.(*CommonDeviceListItem).Client = client

--- a/device.go
+++ b/device.go
@@ -197,6 +197,11 @@ type RelaySwitch1Device struct {
 	CommonDeviceListItem
 }
 
+// RelaySwitch2PMDevice represents a SwitchBot Relay Switch 2PM device
+type RelaySwitch2PMDevice struct {
+	CommonDeviceListItem
+}
+
 type InfraredRemoteDevice struct {
 	Client      *Client
 	DeviceID    string `json:"deviceId"`
@@ -409,6 +414,9 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Relay Switch 1":
 				parsed = &RelaySwitch1Device{}
 				parsed.(*RelaySwitch1Device).Client = client
+			case "Relay Switch 2PM":
+				parsed = &RelaySwitch2PMDevice{}
+				parsed.(*RelaySwitch2PMDevice).Client = client
 			default:
 				parsed = &CommonDeviceListItem{}
 				parsed.(*CommonDeviceListItem).Client = client

--- a/device.go
+++ b/device.go
@@ -125,7 +125,7 @@ type StripLightDevice struct {
 	CommonDeviceListItem
 }
 
-type ColorBulbDevice struct {
+type ColorLightDevice struct {
 	CommonDeviceListItem
 }
 
@@ -375,8 +375,8 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 				parsed = &StripLightDevice{}
 				parsed.(*StripLightDevice).Client = client
 			case "Color Bulb":
-				parsed = &ColorBulbDevice{}
-				parsed.(*ColorBulbDevice).Client = client
+				parsed = &ColorLightDevice{}
+				parsed.(*ColorLightDevice).Client = client
 			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro":
 				parsed = &RobotVacuumCleanerDevice{}
 				parsed.(*RobotVacuumCleanerDevice).Client = client

--- a/device.go
+++ b/device.go
@@ -202,6 +202,11 @@ type RelaySwitch2PMDevice struct {
 	CommonDeviceListItem
 }
 
+// GarageDoorOpenerDevice represents a SwitchBot Garage Door Opener device
+type GarageDoorOpenerDevice struct {
+	CommonDeviceListItem
+}
+
 type InfraredRemoteDevice struct {
 	Client      *Client
 	DeviceID    string `json:"deviceId"`

--- a/device.go
+++ b/device.go
@@ -133,7 +133,7 @@ type RobotVacuumCleanerDevice struct {
 	CommonDeviceListItem
 }
 
-type RobotVacuumCleanerS10Device struct {
+type RobotVacuumCleanerSDevice struct {
 	CommonDeviceListItem
 }
 
@@ -366,9 +366,9 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro", "Robot Vacuum Cleaner K10+ Pro Combo":
 				parsed = &RobotVacuumCleanerDevice{}
 				parsed.(*RobotVacuumCleanerDevice).Client = client
-			case "Robot Vacuum Cleaner S10":
-				parsed = &RobotVacuumCleanerS10Device{}
-				parsed.(*RobotVacuumCleanerS10Device).Client = client
+			case "Robot Vacuum Cleaner S10", "Robot Vacuum Cleaner S20":
+				parsed = &RobotVacuumCleanerSDevice{}
+				parsed.(*RobotVacuumCleanerSDevice).Client = client
 			case "Humidifier":
 				parsed = &HumidifierDevice{}
 				parsed.(*HumidifierDevice).Client = client

--- a/device.go
+++ b/device.go
@@ -137,6 +137,10 @@ type RobotVacuumCleanerSDevice struct {
 	CommonDeviceListItem
 }
 
+type RobotVacuumCleanerComboDevice struct {
+	CommonDeviceListItem
+}
+
 type HumidifierDevice struct {
 	CommonDeviceListItem
 }
@@ -363,9 +367,12 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Color Bulb":
 				parsed = &ColorBulbDevice{}
 				parsed.(*ColorBulbDevice).Client = client
-			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro", "Robot Vacuum Cleaner K10+ Pro Combo":
+			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro":
 				parsed = &RobotVacuumCleanerDevice{}
 				parsed.(*RobotVacuumCleanerDevice).Client = client
+			case "Robot Vacuum Cleaner K10+ Pro Combo":
+				parsed = &RobotVacuumCleanerComboDevice{}
+				parsed.(*RobotVacuumCleanerComboDevice).Client = client
 			case "Robot Vacuum Cleaner S10", "Robot Vacuum Cleaner S20":
 				parsed = &RobotVacuumCleanerSDevice{}
 				parsed.(*RobotVacuumCleanerSDevice).Client = client

--- a/device.go
+++ b/device.go
@@ -77,6 +77,14 @@ type LockDevice struct {
 	LockDevicesIds []string `json:"lockDevicesIds"`
 }
 
+type LockLiteDevice struct {
+	CommonDeviceListItem
+	Group          bool     `json:"group"`
+	Master         bool     `json:"master"`
+	GroupName      string   `json:"groupName"`
+	LockDevicesIds []string `json:"lockDevicesIds"`
+}
+
 type KeyListItem struct {
 	Id         int    `json:"id"`
 	Name       string `json:"name"`
@@ -347,6 +355,9 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Smart Lock", "Smart Lock Pro", "Smart Lock Ultra":
 				parsed = &LockDevice{}
 				parsed.(*LockDevice).Client = client
+			case "Smart Lock Lite":
+				parsed = &LockLiteDevice{}
+				parsed.(*LockLiteDevice).Client = client
 			case "Keypad", "Keypad Touch":
 				parsed = &KeypadDevice{}
 				parsed.(*KeypadDevice).Client = client

--- a/device.go
+++ b/device.go
@@ -370,7 +370,7 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro":
 				parsed = &RobotVacuumCleanerDevice{}
 				parsed.(*RobotVacuumCleanerDevice).Client = client
-			case "Robot Vacuum Cleaner K10+ Pro Combo":
+			case "Robot Vacuum Cleaner K10+ Pro Combo", "Robot Vacuum Cleaner K20 Plus Pro":
 				parsed = &RobotVacuumCleanerComboDevice{}
 				parsed.(*RobotVacuumCleanerComboDevice).Client = client
 			case "Robot Vacuum Cleaner S10", "Robot Vacuum Cleaner S20":

--- a/device.go
+++ b/device.go
@@ -374,7 +374,7 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Strip Light":
 				parsed = &StripLightDevice{}
 				parsed.(*StripLightDevice).Client = client
-			case "Color Bulb":
+			case "Color Bulb", "Floor Lamp", "Strip Light 3":
 				parsed = &ColorLightDevice{}
 				parsed.(*ColorLightDevice).Client = client
 			case "Robot Vacuum Cleaner S1", "Robot Vacuum Cleaner S1 Plus", "K10+", "K10+ Pro":

--- a/device.go
+++ b/device.go
@@ -57,6 +57,10 @@ type Hub2Device struct {
 	CommonDeviceListItem
 }
 
+type Hub3Device struct {
+	CommonDeviceListItem
+}
+
 type MeterDevice struct {
 	CommonDeviceListItem
 }
@@ -317,6 +321,9 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Hub 2":
 				parsed = &Hub2Device{}
 				parsed.(*Hub2Device).Client = client
+			case "Hub 3":
+				parsed = &Hub3Device{}
+				parsed.(*Hub3Device).Client = client
 			case "Meter", "MeterPlus", "WoIOSensor", "MeterPro":
 				parsed = &MeterDevice{}
 				parsed.(*MeterDevice).Client = client

--- a/device.go
+++ b/device.go
@@ -363,7 +363,7 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "Smart Lock Lite":
 				parsed = &LockLiteDevice{}
 				parsed.(*LockLiteDevice).Client = client
-			case "Keypad", "Keypad Touch":
+			case "Keypad", "Keypad Touch", "Keypad Vision":
 				parsed = &KeypadDevice{}
 				parsed.(*KeypadDevice).Client = client
 			case "Remote":

--- a/device.go
+++ b/device.go
@@ -330,7 +330,7 @@ func GetDevicesResponseParser(response *GetDevicesResponse) ResponseParser {
 			case "MeterPro(CO2)":
 				parsed = &MeterProCo2Device{}
 				parsed.(*MeterProCo2Device).Client = client
-			case "Smart Lock", "Smart Lock Pro":
+			case "Smart Lock", "Smart Lock Pro", "Smart Lock Ultra":
 				parsed = &LockDevice{}
 				parsed.(*LockDevice).Client = client
 			case "Keypad", "Keypad Touch":

--- a/device_control.go
+++ b/device_control.go
@@ -961,6 +961,69 @@ func (device *RelaySwitch1Device) SetMode(mode RelaySwitchMode) (*CommonResponse
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
+// TurnOn sends a command to turn on the specified switch of the RelaySwitch2PMDevice
+// switchNum: 1 for switch 1, 2 for switch 2
+func (device *RelaySwitch2PMDevice) TurnOn(switchNum int) (*CommonResponse, error) {
+	if err := validate2PMDeviceSwitchNumber(switchNum); err != nil {
+		return nil, err
+	}
+	return device.Client.SendCommand(device.DeviceID, ControlRequest{
+		CommandType: "command",
+		Command:     "turnOn",
+		Parameter:   fmt.Sprintf("%d", switchNum),
+	})
+}
+
+// TurnOff sends a command to turn off the specified switch of the RelaySwitch2PMDevice
+// switchNum: 1 for switch 1, 2 for switch 2
+func (device *RelaySwitch2PMDevice) TurnOff(switchNum int) (*CommonResponse, error) {
+	if err := validate2PMDeviceSwitchNumber(switchNum); err != nil {
+		return nil, err
+	}
+	return device.Client.SendCommand(device.DeviceID, ControlRequest{
+		CommandType: "command",
+		Command:     "turnOff",
+		Parameter:   fmt.Sprintf("%d", switchNum),
+	})
+}
+
+// Toggle sends a command to toggle the specified switch of the RelaySwitch2PMDevice
+// switchNum: 1 for switch 1, 2 for switch 2
+func (device *RelaySwitch2PMDevice) Toggle(switchNum int) (*CommonResponse, error) {
+	if err := validate2PMDeviceSwitchNumber(switchNum); err != nil {
+		return nil, err
+	}
+	return device.Client.SendCommand(device.DeviceID, ControlRequest{
+		CommandType: "command",
+		Command:     "toggle",
+		Parameter:   fmt.Sprintf("%d", switchNum),
+	})
+}
+
+// SetMode sends a command to set the mode of the RelaySwitch2PMDevice
+func (device *RelaySwitch2PMDevice) SetMode(switchNum int, mode RelaySwitchMode) (*CommonResponse, error) {
+	if err := validate2PMDeviceSwitchNumber(switchNum); err != nil {
+		return nil, err
+	}
+	if mode < 0 || mode > 3 {
+		return nil, fmt.Errorf("invalid mode: %d, must be between 0 and 3", mode)
+	}
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "setMode",
+		Parameter:   fmt.Sprintf("%d,%d", switchNum, mode),
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// validate2PMDeviceSwitchNumber checks if the switch number is valid (1 or 2)
+func validate2PMDeviceSwitchNumber(switchNumber int) error {
+	if switchNumber < 1 || switchNumber > 2 {
+		return fmt.Errorf("invalid switch number: %d, must be 1 or 2", switchNumber)
+	}
+	return nil
+}
+
 // TurnOn sends a command to turn on the InfraredRemoteDevice
 func (device *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")

--- a/device_control.go
+++ b/device_control.go
@@ -400,8 +400,8 @@ func NewFloorCleaningParam(fanLevel int, waterLevel int, times int) (*FloorClean
 	}, nil
 }
 
-// StartClean sends a command to start cleaning the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) StartClean(startFloorCleaningParam *StartFloorCleaningParam) (*CommonResponse, error) {
+// StartClean sends a command to start cleaning the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) StartClean(startFloorCleaningParam *StartFloorCleaningParam) (*CommonResponse, error) {
 	request := ControlRequest{
 		CommandType: "command",
 		Command:     "startClean",
@@ -410,23 +410,23 @@ func (device *RobotVacuumCleanerS10Device) StartClean(startFloorCleaningParam *S
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-// AddWaterForHumi sends a command to refill the mind-blowing Evaporative Humidifier (Auto-refill) in the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) AddWaterForHumi() (*CommonResponse, error) {
+// AddWaterForHumi sends a command to refill the mind-blowing Evaporative Humidifier (Auto-refill) in the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) AddWaterForHumi() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "addWaterForHumi")
 }
 
-// Pause sends a command to pause the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) Pause() (*CommonResponse, error) {
+// Pause sends a command to pause the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) Pause() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "pause")
 }
 
-// Dock sends a command to return the RobotVacuumCleanerS10Device to its charging dock.
-func (device *RobotVacuumCleanerS10Device) Dock() (*CommonResponse, error) {
+// Dock sends a command to return the RobotVacuumCleanerSDevice to its charging dock.
+func (device *RobotVacuumCleanerSDevice) Dock() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "dock")
 }
 
-// SetVolume sends a command to set the volume of the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) SetVolume(volume int) (*CommonResponse, error) {
+// SetVolume sends a command to set the volume of the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) SetVolume(volume int) (*CommonResponse, error) {
 	if volume < 0 || volume > 100 {
 		return nil, fmt.Errorf("invalid volume: %d", volume)
 	}
@@ -446,8 +446,8 @@ const (
 	TerminateSelfCleaningMode = SelfCleaningMode(3)
 )
 
-// SelfClean sends a command to start self-cleaning the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) SelfClean(mode SelfCleaningMode) (*CommonResponse, error) {
+// SelfClean sends a command to start self-cleaning the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) SelfClean(mode SelfCleaningMode) (*CommonResponse, error) {
 	if mode < 1 || mode > 3 {
 		return nil, fmt.Errorf("invalid mode: %d", mode)
 	}
@@ -459,8 +459,8 @@ func (device *RobotVacuumCleanerS10Device) SelfClean(mode SelfCleaningMode) (*Co
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-// ChangeParam sends a command to change the cleaning parameters of the RobotVacuumCleanerS10Device.
-func (device *RobotVacuumCleanerS10Device) ChangeParam(floorCleaningParam *FloorCleaningParam) (*CommonResponse, error) {
+// ChangeParam sends a command to change the cleaning parameters of the RobotVacuumCleanerSDevice.
+func (device *RobotVacuumCleanerSDevice) ChangeParam(floorCleaningParam *FloorCleaningParam) (*CommonResponse, error) {
 	request := ControlRequest{
 		CommandType: "command",
 		Command:     "changeParam",

--- a/device_control.go
+++ b/device_control.go
@@ -94,6 +94,16 @@ func (device *LockDevice) Unlock() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "unlock")
 }
 
+// Lock sends a command to lock the LockLiteDevice
+func (device *LockLiteDevice) Lock() (*CommonResponse, error) {
+	return sendDefaultParameterCommand(device.Client, device.DeviceID, "lock")
+}
+
+// Unlock sends a command to unlock the LockLiteDevice
+func (device *LockLiteDevice) Unlock() (*CommonResponse, error) {
+	return sendDefaultParameterCommand(device.Client, device.DeviceID, "unlock")
+}
+
 type KeypadKey struct {
 	Name      string `json:"name"`
 	Type      string `json:"type"`

--- a/device_control.go
+++ b/device_control.go
@@ -260,23 +260,23 @@ func (device *StripLightDevice) SetColor(color color.RGBA) (*CommonResponse, err
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-// TurnOn sends a command to turn on the ColorBulbDevice
-func (device *ColorBulbDevice) TurnOn() (*CommonResponse, error) {
+// TurnOn sends a command to turn on the ColorLightDevice
+func (device *ColorLightDevice) TurnOn() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")
 }
 
-// TurnOff sends a command to turn off the ColorBulbDevice
-func (device *ColorBulbDevice) TurnOff() (*CommonResponse, error) {
+// TurnOff sends a command to turn off the ColorLightDevice
+func (device *ColorLightDevice) TurnOff() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOff")
 }
 
-// Toggle sends a command to toggle the ColorBulbDevice
-func (device *ColorBulbDevice) Toggle() (*CommonResponse, error) {
+// Toggle sends a command to toggle the ColorLightDevice
+func (device *ColorLightDevice) Toggle() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "toggle")
 }
 
-// SetBrightness sends a command to set the brightness of the ColorBulbDevice
-func (device *ColorBulbDevice) SetBrightness(brightness int) (*CommonResponse, error) {
+// SetBrightness sends a command to set the brightness of the ColorLightDevice
+func (device *ColorLightDevice) SetBrightness(brightness int) (*CommonResponse, error) {
 	if brightness < 1 || brightness > 100 {
 		return nil, fmt.Errorf("invalid brightness: %d", brightness)
 	}
@@ -288,8 +288,8 @@ func (device *ColorBulbDevice) SetBrightness(brightness int) (*CommonResponse, e
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-// SetColor sends a command to set the color of the ColorBulbDevice
-func (device *ColorBulbDevice) SetColor(color color.RGBA) (*CommonResponse, error) {
+// SetColor sends a command to set the color of the ColorLightDevice
+func (device *ColorLightDevice) SetColor(color color.RGBA) (*CommonResponse, error) {
 	request := ControlRequest{
 		CommandType: "command",
 		Command:     "setColor",
@@ -298,8 +298,8 @@ func (device *ColorBulbDevice) SetColor(color color.RGBA) (*CommonResponse, erro
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
-// SetColorTemperature sends a command to set the color temperature of the ColorBulbDevice
-func (device *ColorBulbDevice) SetColorTemperature(colorTemperature int) (*CommonResponse, error) {
+// SetColorTemperature sends a command to set the color temperature of the ColorLightDevice
+func (device *ColorLightDevice) SetColorTemperature(colorTemperature int) (*CommonResponse, error) {
 	if colorTemperature < 2700 || colorTemperature > 6500 {
 		return nil, fmt.Errorf("invalid colorTemperature: %d", colorTemperature)
 	}

--- a/device_control.go
+++ b/device_control.go
@@ -469,6 +469,109 @@ func (device *RobotVacuumCleanerSDevice) ChangeParam(floorCleaningParam *FloorCl
 	return device.Client.SendCommand(device.DeviceID, request)
 }
 
+// FloorCleaningActionCombo represents the action to be performed in floor cleaning mode for Combo devices.
+type FloorCleaningActionCombo string
+
+const (
+	FloorCleaningActionSweepCombo FloorCleaningActionCombo = "sweep"
+	FloorCleaningActionMopCombo   FloorCleaningActionCombo = "mop"
+)
+
+// FloorCleaningComboParam represents the parameters for floor cleaning mode for Combo devices.
+type FloorCleaningComboParam struct {
+	FanLevel int `json:"fanLevel"`
+	Times    int `json:"times"`
+}
+
+// StartFloorCleaningComboParam represents the parameters for starting floor cleaning mode for Combo devices.
+type StartFloorCleaningComboParam struct {
+	Action FloorCleaningActionCombo `json:"action"`
+	Param  FloorCleaningComboParam  `json:"param"`
+}
+
+// NewFloorCleaningComboParam creates a new FloorCleaningComboParam instance with validation.
+func NewFloorCleaningComboParam(fanLevel int, times int) (*FloorCleaningComboParam, error) {
+	if fanLevel < 1 || fanLevel > 4 {
+		return nil, fmt.Errorf("invalid fanLevel: %d", fanLevel)
+	}
+
+	if times < 1 || times > 2639999 {
+		return nil, fmt.Errorf("invalid times: %d", times)
+	}
+
+	return &FloorCleaningComboParam{
+		FanLevel: fanLevel,
+		Times:    times,
+	}, nil
+}
+
+// NewStartFloorCleaningComboParam creates a new StartFloorCleaningComboParam instance with validation.
+func NewStartFloorCleaningComboParam(action FloorCleaningActionCombo, fanLevel int, times int) (*StartFloorCleaningComboParam, error) {
+	param, err := NewFloorCleaningComboParam(fanLevel, times)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StartFloorCleaningComboParam{
+		Action: action,
+		Param:  *param,
+	}, nil
+}
+
+// StartClean sends a command to start cleaning the RobotVacuumCleanerComboDevice.
+func (device *RobotVacuumCleanerComboDevice) StartClean(startFloorCleaningParam *StartFloorCleaningComboParam) (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "startClean",
+		Parameter:   startFloorCleaningParam,
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Pause sends a command to pause the RobotVacuumCleanerComboDevice.
+func (device *RobotVacuumCleanerComboDevice) Pause() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "pause",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// Dock sends a command to return the RobotVacuumCleanerComboDevice to its charging dock.
+func (device *RobotVacuumCleanerComboDevice) Dock() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "dock",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// SetVolume sends a command to set the volume of the RobotVacuumCleanerComboDevice.
+func (device *RobotVacuumCleanerComboDevice) SetVolume(volume int) (*CommonResponse, error) {
+	if volume < 0 || volume > 100 {
+		return nil, fmt.Errorf("volume must be between 0 and 100")
+	}
+
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "setVolume",
+		Parameter:   fmt.Sprintf("%d", volume),
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// ChangeParam sends a command to change the cleaning parameters of the RobotVacuumCleanerComboDevice.
+func (device *RobotVacuumCleanerComboDevice) ChangeParam(floorCleaningParam *FloorCleaningParam) (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "changeParam",
+		Parameter:   floorCleaningParam,
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
 // TurnOn sends a command to turn on the HumidifierDevice
 func (device *HumidifierDevice) TurnOn() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")

--- a/device_control.go
+++ b/device_control.go
@@ -1024,6 +1024,16 @@ func validate2PMDeviceSwitchNumber(switchNumber int) error {
 	return nil
 }
 
+// TurnOn sends a command to turn on the GarageDoorOpenerDevice
+func (device *GarageDoorOpenerDevice) TurnOn() (*CommonResponse, error) {
+	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")
+}
+
+// TurnOff sends a command to turn off the GarageDoorOpenerDevice
+func (device *GarageDoorOpenerDevice) TurnOff() (*CommonResponse, error) {
+	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOff")
+}
+
 // TurnOn sends a command to turn on the InfraredRemoteDevice
 func (device *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")

--- a/device_control.go
+++ b/device_control.go
@@ -1044,6 +1044,26 @@ func (device *GarageDoorOpenerDevice) TurnOff() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOff")
 }
 
+// EnableMotionDetection enables motion detection on the Video Doorbell
+func (device *VideoDoorbellDevice) EnableMotionDetection() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "enableMotionDetection",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
+// DisableMotionDetection disables motion detection on the Video Doorbell
+func (device *VideoDoorbellDevice) DisableMotionDetection() (*CommonResponse, error) {
+	request := ControlRequest{
+		CommandType: "command",
+		Command:     "disableMotionDetection",
+		Parameter:   "default",
+	}
+	return device.Client.SendCommand(device.DeviceID, request)
+}
+
 // TurnOn sends a command to turn on the InfraredRemoteDevice
 func (device *InfraredRemoteDevice) TurnOn() (*CommonResponse, error) {
 	return sendDefaultParameterCommand(device.Client, device.DeviceID, "turnOn")

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -485,9 +485,9 @@ func (device *StripLightDevice) GetCommandParameterJSONSchema() (string, error) 
 	return reflectJSONSchema(StripLightDeviceCommandParameter{})
 }
 
-// ColorBulbDeviceCommandParameter is a struct that represents the command parameter for the ColorBulbDevice
-type ColorBulbDeviceCommandParameter struct {
-	Command          string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,Toggle,SetBrightness,SetColor,SetColorTemperature" description:"TurnOn:turn on the bulb, TurnOff:turn off the bulb, Toggle:toggle the bulb, SetBrightness:set brightness, SetColor:set color, SetColorTemperature:set color temperature" required:"true"`
+// ColorLightDeviceCommandParameter is a struct that represents the command parameter for the ColorLightDevice
+type ColorLightDeviceCommandParameter struct {
+	Command          string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,Toggle,SetBrightness,SetColor,SetColorTemperature" description:"TurnOn:turn on the light, TurnOff:turn off the light, Toggle:toggle the light, SetBrightness:set brightness, SetColor:set color, SetColorTemperature:set color temperature" required:"true"`
 	Brightness       int      `json:"brightness" title:"Brightness" minimum:"1" maximum:"100" description:"Brightness level (1-100)"`
 	Red              int      `json:"red" title:"Red" minimum:"0" maximum:"255" description:"Red color value (0-255)"`
 	Green            int      `json:"green" title:"Green" minimum:"0" maximum:"255" description:"Green color value (0-255)"`
@@ -496,35 +496,35 @@ type ColorBulbDeviceCommandParameter struct {
 	_                struct{} `additionalProperties:"false"`
 }
 
-// ColorBulbDeviceCommandSetBrightnessIfExposer represents the SetBrightness command parameters
-type ColorBulbDeviceCommandSetBrightnessIfExposer struct{}
+// ColorLightDeviceCommandSetBrightnessIfExposer represents the SetBrightness command parameters
+type ColorLightDeviceCommandSetBrightnessIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the ColorBulbDevice command parameter for SetBrightness
-func (parameter *ColorBulbDeviceCommandSetBrightnessIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the ColorLightDevice command parameter for SetBrightness
+func (parameter *ColorLightDeviceCommandSetBrightnessIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"SetBrightness" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the ColorBulbDevice command parameter for SetBrightness
-func (parameter *ColorBulbDeviceCommandSetBrightnessIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the ColorLightDevice command parameter for SetBrightness
+func (parameter *ColorLightDeviceCommandSetBrightnessIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		Brightness int `json:"brightness" required:"true"`
 	}{}
 }
 
-// ColorBulbDeviceCommandSetColorIfExposer represents the SetColor command parameters
-type ColorBulbDeviceCommandSetColorIfExposer struct{}
+// ColorLightDeviceCommandSetColorIfExposer represents the SetColor command parameters
+type ColorLightDeviceCommandSetColorIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the ColorBulbDevice command parameter for SetColor
-func (parameter *ColorBulbDeviceCommandSetColorIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the ColorLightDevice command parameter for SetColor
+func (parameter *ColorLightDeviceCommandSetColorIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"SetColor" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the ColorBulbDevice command parameter for SetColor
-func (parameter *ColorBulbDeviceCommandSetColorIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the ColorLightDevice command parameter for SetColor
+func (parameter *ColorLightDeviceCommandSetColorIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		Red   int `json:"red" required:"true"`
 		Green int `json:"green" required:"true"`
@@ -532,35 +532,35 @@ func (parameter *ColorBulbDeviceCommandSetColorIfExposer) JSONSchemaThen() inter
 	}{}
 }
 
-// ColorBulbDeviceCommandSetColorTemperatureIfExposer represents the SetColorTemperature command parameters
-type ColorBulbDeviceCommandSetColorTemperatureIfExposer struct{}
+// ColorLightDeviceCommandSetColorTemperatureIfExposer represents the SetColorTemperature command parameters
+type ColorLightDeviceCommandSetColorTemperatureIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the ColorBulbDevice command parameter for SetColorTemperature
-func (parameter *ColorBulbDeviceCommandSetColorTemperatureIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the ColorLightDevice command parameter for SetColorTemperature
+func (parameter *ColorLightDeviceCommandSetColorTemperatureIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"SetColorTemperature" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the ColorBulbDevice command parameter for SetColorTemperature
-func (parameter *ColorBulbDeviceCommandSetColorTemperatureIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the ColorLightDevice command parameter for SetColorTemperature
+func (parameter *ColorLightDeviceCommandSetColorTemperatureIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		ColorTemperature int `json:"colorTemperature" required:"true"`
 	}{}
 }
 
-// JSONSchemaAllOf returns the JSON schema allOf block for the ColorBulbDevice command parameter
-func (parameter *ColorBulbDeviceCommandParameter) JSONSchemaAllOf() []interface{} {
+// JSONSchemaAllOf returns the JSON schema allOf block for the ColorLightDevice command parameter
+func (parameter *ColorLightDeviceCommandParameter) JSONSchemaAllOf() []interface{} {
 	return []interface{}{
-		&ColorBulbDeviceCommandSetBrightnessIfExposer{},
-		&ColorBulbDeviceCommandSetColorIfExposer{},
-		&ColorBulbDeviceCommandSetColorTemperatureIfExposer{},
+		&ColorLightDeviceCommandSetBrightnessIfExposer{},
+		&ColorLightDeviceCommandSetColorIfExposer{},
+		&ColorLightDeviceCommandSetColorTemperatureIfExposer{},
 	}
 }
 
-// ExecCommand sends a command to the ColorBulbDevice
-func (device *ColorBulbDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
-	var parameter ColorBulbDeviceCommandParameter
+// ExecCommand sends a command to the ColorLightDevice
+func (device *ColorLightDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter ColorLightDeviceCommandParameter
 	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
 		return nil, err
 	}
@@ -583,9 +583,9 @@ func (device *ColorBulbDevice) ExecCommand(jsonString string) (*CommonResponse, 
 	}
 }
 
-// GetCommandParameterJSONSchema returns the JSON schema for the ColorBulbDevice command parameter
-func (device *ColorBulbDevice) GetCommandParameterJSONSchema() (string, error) {
-	return reflectJSONSchema(ColorBulbDeviceCommandParameter{})
+// GetCommandParameterJSONSchema returns the JSON schema for the ColorLightDevice command parameter
+func (device *ColorLightDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(ColorLightDeviceCommandParameter{})
 }
 
 // RobotVacuumCleanerDeviceCommandParameter is a struct that represents the command parameter for the RobotVacuumCleanerDevice

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -645,8 +645,8 @@ func (device *RobotVacuumCleanerDevice) GetCommandParameterJSONSchema() (string,
 	return reflectJSONSchema(RobotVacuumCleanerDeviceCommandParameter{})
 }
 
-// RobotVacuumCleanerS10DeviceCommandParameter is a struct that represents the command parameter for the RobotVacuumCleanerS10Device
-type RobotVacuumCleanerS10DeviceCommandParameter struct {
+// RobotVacuumCleanerSDeviceCommandParameter is a struct that represents the command parameter for the RobotVacuumCleanerSDevice
+type RobotVacuumCleanerSDeviceCommandParameter struct {
 	Command    string   `json:"command" title:"Command" enum:"StartClean,AddWaterForHumi,Pause,Dock,SetVolume,SelfClean,ChangeParam" description:"StartClean:start cleaning, AddWaterForHumi:refill the humidifier, Pause:pause cleaning, Dock:return to charging dock, SetVolume:set volume level, SelfClean:start self-cleaning, ChangeParam:change cleaning parameters" required:"true"`
 	Action     string   `json:"action" title:"Action" enum:"sweep,sweep_mop" description:"sweep:sweep only, sweep_mop:sweep and mop"`
 	FanLevel   int      `json:"fanLevel" title:"FanLevel" minimum:"1" maximum:"4" description:"Fan level (1-4)"`
@@ -657,18 +657,18 @@ type RobotVacuumCleanerS10DeviceCommandParameter struct {
 	_          struct{} `additionalProperties:"false"`
 }
 
-// RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer represents the StartClean command parameters
-type RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer struct{}
+// RobotVacuumCleanerSDeviceCommandStartCleanIfExposer represents the StartClean command parameters
+type RobotVacuumCleanerSDeviceCommandStartCleanIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerS10Device command parameter for StartClean
-func (parameter *RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerSDevice command parameter for StartClean
+func (parameter *RobotVacuumCleanerSDeviceCommandStartCleanIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"StartClean" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerS10Device command parameter for StartClean
-func (parameter *RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerSDevice command parameter for StartClean
+func (parameter *RobotVacuumCleanerSDeviceCommandStartCleanIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		Action     string `json:"action" required:"true"`
 		FanLevel   int    `json:"fanLevel" required:"true"`
@@ -677,52 +677,52 @@ func (parameter *RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer) JSONSche
 	}{}
 }
 
-// RobotVacuumCleanerS10DeviceCommandSetVolumeIfExposer represents the SetVolume command parameters
-type RobotVacuumCleanerS10DeviceCommandSetVolumeIfExposer struct{}
+// RobotVacuumCleanerSDeviceCommandSetVolumeIfExposer represents the SetVolume command parameters
+type RobotVacuumCleanerSDeviceCommandSetVolumeIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerS10Device command parameter for SetVolume
-func (parameter *RobotVacuumCleanerS10DeviceCommandSetVolumeIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerSDevice command parameter for SetVolume
+func (parameter *RobotVacuumCleanerSDeviceCommandSetVolumeIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"SetVolume" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerS10Device command parameter for SetVolume
-func (parameter *RobotVacuumCleanerS10DeviceCommandSetVolumeIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerSDevice command parameter for SetVolume
+func (parameter *RobotVacuumCleanerSDeviceCommandSetVolumeIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		Volume int `json:"volume" required:"true"`
 	}{}
 }
 
-// RobotVacuumCleanerS10DeviceCommandSelfCleanIfExposer represents the SelfClean command parameters
-type RobotVacuumCleanerS10DeviceCommandSelfCleanIfExposer struct{}
+// RobotVacuumCleanerSDeviceCommandSelfCleanIfExposer represents the SelfClean command parameters
+type RobotVacuumCleanerSDeviceCommandSelfCleanIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerS10Device command parameter for SelfClean
-func (parameter *RobotVacuumCleanerS10DeviceCommandSelfCleanIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerSDevice command parameter for SelfClean
+func (parameter *RobotVacuumCleanerSDeviceCommandSelfCleanIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"SelfClean" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerS10Device command parameter for SelfClean
-func (parameter *RobotVacuumCleanerS10DeviceCommandSelfCleanIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerSDevice command parameter for SelfClean
+func (parameter *RobotVacuumCleanerSDeviceCommandSelfCleanIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		Mode int `json:"mode" required:"true"`
 	}{}
 }
 
-// RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer represents the ChangeParam command parameters
-type RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer struct{}
+// RobotVacuumCleanerSDeviceCommandChangeParamIfExposer represents the ChangeParam command parameters
+type RobotVacuumCleanerSDeviceCommandChangeParamIfExposer struct{}
 
-// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerS10Device command parameter for ChangeParam
-func (parameter *RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer) JSONSchemaIf() interface{} {
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerSDevice command parameter for ChangeParam
+func (parameter *RobotVacuumCleanerSDeviceCommandChangeParamIfExposer) JSONSchemaIf() interface{} {
 	return struct {
 		Command string `json:"command" const:"ChangeParam" required:"true"`
 	}{}
 }
 
-// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerS10Device command parameter for ChangeParam
-func (parameter *RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer) JSONSchemaThen() interface{} {
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerSDevice command parameter for ChangeParam
+func (parameter *RobotVacuumCleanerSDeviceCommandChangeParamIfExposer) JSONSchemaThen() interface{} {
 	return struct {
 		FanLevel   int `json:"fanLevel" required:"true"`
 		WaterLevel int `json:"waterLevel" required:"true"`
@@ -730,19 +730,19 @@ func (parameter *RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer) JSONSch
 	}{}
 }
 
-// JSONSchemaAllOf returns the JSON schema allOf block for the RobotVacuumCleanerS10Device command parameter
-func (parameter *RobotVacuumCleanerS10DeviceCommandParameter) JSONSchemaAllOf() []interface{} {
+// JSONSchemaAllOf returns the JSON schema allOf block for the RobotVacuumCleanerSDevice command parameter
+func (parameter *RobotVacuumCleanerSDeviceCommandParameter) JSONSchemaAllOf() []interface{} {
 	return []interface{}{
-		&RobotVacuumCleanerS10DeviceCommandStartCleanIfExposer{},
-		&RobotVacuumCleanerS10DeviceCommandSetVolumeIfExposer{},
-		&RobotVacuumCleanerS10DeviceCommandSelfCleanIfExposer{},
-		&RobotVacuumCleanerS10DeviceCommandChangeParamIfExposer{},
+		&RobotVacuumCleanerSDeviceCommandStartCleanIfExposer{},
+		&RobotVacuumCleanerSDeviceCommandSetVolumeIfExposer{},
+		&RobotVacuumCleanerSDeviceCommandSelfCleanIfExposer{},
+		&RobotVacuumCleanerSDeviceCommandChangeParamIfExposer{},
 	}
 }
 
-// ExecCommand sends a command to the RobotVacuumCleanerS10Device
-func (device *RobotVacuumCleanerS10Device) ExecCommand(jsonString string) (*CommonResponse, error) {
-	var parameter RobotVacuumCleanerS10DeviceCommandParameter
+// ExecCommand sends a command to the RobotVacuumCleanerSDevice
+func (device *RobotVacuumCleanerSDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter RobotVacuumCleanerSDeviceCommandParameter
 	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
 		return nil, err
 	}
@@ -775,9 +775,9 @@ func (device *RobotVacuumCleanerS10Device) ExecCommand(jsonString string) (*Comm
 	}
 }
 
-// GetCommandParameterJSONSchema returns the JSON schema for the RobotVacuumCleanerS10Device command parameter
-func (device *RobotVacuumCleanerS10Device) GetCommandParameterJSONSchema() (string, error) {
-	return reflectJSONSchema(RobotVacuumCleanerS10DeviceCommandParameter{})
+// GetCommandParameterJSONSchema returns the JSON schema for the RobotVacuumCleanerSDevice command parameter
+func (device *RobotVacuumCleanerSDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(RobotVacuumCleanerSDeviceCommandParameter{})
 }
 
 // HumidifierDeviceCommandParameter is a struct that represents the command parameter for the HumidifierDevice

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -780,6 +780,119 @@ func (device *RobotVacuumCleanerSDevice) GetCommandParameterJSONSchema() (string
 	return reflectJSONSchema(RobotVacuumCleanerSDeviceCommandParameter{})
 }
 
+// RobotVacuumCleanerComboDeviceCommandParameter is a struct that represents the command parameter for the RobotVacuumCleanerComboDevice
+type RobotVacuumCleanerComboDeviceCommandParameter struct {
+	Command    string `json:"command" title:"Command" enum:"startClean,pause,dock,setVolume,changeParam" description:"startClean:start cleaning, pause:pause cleaning, dock:return to charging dock, setVolume:set volume level, changeParam:change cleaning parameters" required:"true"`
+	Action     string `json:"action" title:"Action" enum:"sweep,mop" description:"sweep:sweep only, mop:mop only"`
+	FanLevel   int    `json:"fanLevel" title:"FanLevel" minimum:"1" maximum:"4" description:"Fan level (1-4)"`
+	WaterLevel int    `json:"waterLevel" title:"WaterLevel" minimum:"1" maximum:"2" description:"Water level (1-2)"`
+	Times      int    `json:"times" title:"Times" minimum:"1" maximum:"2639999" description:"the number of cycles"`
+	Volume     int    `json:"volume" title:"Volume" minimum:"0" maximum:"100" description:"Volume level (0-100)"`
+
+	_ struct{} `additionalProperties:"false"`
+}
+
+// RobotVacuumCleanerComboDeviceCommandStartCleanIfExposer represents the startClean command parameters
+type RobotVacuumCleanerComboDeviceCommandStartCleanIfExposer struct{}
+
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerComboDevice command parameter for startClean
+func (parameter *RobotVacuumCleanerComboDeviceCommandStartCleanIfExposer) JSONSchemaIf() interface{} {
+	return struct {
+		Command string `json:"command" const:"startClean" required:"true"`
+	}{}
+}
+
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerComboDevice command parameter for startClean
+func (parameter *RobotVacuumCleanerComboDeviceCommandStartCleanIfExposer) JSONSchemaThen() interface{} {
+	return struct {
+		Action   string `json:"action" required:"true"`
+		FanLevel int    `json:"fanLevel" required:"true"`
+		Times    int    `json:"times" required:"true"`
+	}{}
+}
+
+// RobotVacuumCleanerComboDeviceCommandSetVolumeIfExposer represents the setVolume command parameters
+type RobotVacuumCleanerComboDeviceCommandSetVolumeIfExposer struct{}
+
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerComboDevice command parameter for setVolume
+func (parameter *RobotVacuumCleanerComboDeviceCommandSetVolumeIfExposer) JSONSchemaIf() interface{} {
+	return struct {
+		Command string `json:"command" const:"setVolume" required:"true"`
+	}{}
+}
+
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerComboDevice command parameter for setVolume
+func (parameter *RobotVacuumCleanerComboDeviceCommandSetVolumeIfExposer) JSONSchemaThen() interface{} {
+	return struct {
+		Volume int `json:"volume" required:"true"`
+	}{}
+}
+
+// RobotVacuumCleanerComboDeviceCommandChangeParamIfExposer represents the changeParam command parameters
+type RobotVacuumCleanerComboDeviceCommandChangeParamIfExposer struct{}
+
+// JSONSchemaIf returns the JSON schema if block for the RobotVacuumCleanerComboDevice command parameter for changeParam
+func (parameter *RobotVacuumCleanerComboDeviceCommandChangeParamIfExposer) JSONSchemaIf() interface{} {
+	return struct {
+		Command string `json:"command" const:"changeParam" required:"true"`
+	}{}
+}
+
+// JSONSchemaThen returns the JSON schema then block for the RobotVacuumCleanerComboDevice command parameter for changeParam
+func (parameter *RobotVacuumCleanerComboDeviceCommandChangeParamIfExposer) JSONSchemaThen() interface{} {
+	return struct {
+		FanLevel   int `json:"fanLevel" required:"true"`
+		WaterLevel int `json:"waterLevel" required:"true"`
+		Times      int `json:"times" required:"true"`
+	}{}
+}
+
+// JSONSchemaAllOf returns the JSON schema allOf block for the RobotVacuumCleanerComboDevice command parameter
+func (parameter *RobotVacuumCleanerComboDeviceCommandParameter) JSONSchemaAllOf() []interface{} {
+	return []interface{}{
+		&RobotVacuumCleanerComboDeviceCommandStartCleanIfExposer{},
+		&RobotVacuumCleanerComboDeviceCommandSetVolumeIfExposer{},
+		&RobotVacuumCleanerComboDeviceCommandChangeParamIfExposer{},
+	}
+}
+
+// ExecCommand sends a command to the RobotVacuumCleanerComboDevice
+func (device *RobotVacuumCleanerComboDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter RobotVacuumCleanerComboDeviceCommandParameter
+	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
+		return nil, err
+	}
+
+	switch parameter.Command {
+	case "startClean":
+		action := FloorCleaningActionCombo(parameter.Action)
+		startParam, err := NewStartFloorCleaningComboParam(action, parameter.FanLevel, parameter.Times)
+		if err != nil {
+			return nil, err
+		}
+		return device.StartClean(startParam)
+	case "pause":
+		return device.Pause()
+	case "dock":
+		return device.Dock()
+	case "setVolume":
+		return device.SetVolume(parameter.Volume)
+	case "changeParam":
+		floorParam, err := NewFloorCleaningParam(parameter.FanLevel, parameter.WaterLevel, parameter.Times)
+		if err != nil {
+			return nil, err
+		}
+		return device.ChangeParam(floorParam)
+	default:
+		return nil, fmt.Errorf("invalid Command: %s", parameter.Command)
+	}
+}
+
+// GetCommandParameterJSONSchema returns the JSON schema for the RobotVacuumCleanerComboDevice command parameter
+func (device *RobotVacuumCleanerComboDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(RobotVacuumCleanerComboDeviceCommandParameter{})
+}
+
 // HumidifierDeviceCommandParameter is a struct that represents the command parameter for the HumidifierDevice
 type HumidifierDeviceCommandParameter struct {
 	Command        string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,SetMode,SetTargetHumidity" description:"TurnOn:turn on the humidifier, TurnOff:turn off the humidifier, SetMode:set the mode of the humidifier, SetTargetHumidity:set the target humidity" required:"true"`

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -1461,6 +1461,64 @@ func (device *RelaySwitch1PMDevice) GetCommandParameterJSONSchema() (string, err
 	return reflectJSONSchema(RelaySwitch1DeviceCommandParameter{})
 }
 
+// RelaySwitch2PMDeviceCommandParameter is a struct that represents the command parameter for the RelaySwitch2PMDevice
+type RelaySwitch2PMDeviceCommandParameter struct {
+	Command string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,Toggle,SetMode" description:"TurnOn:turn on the relay switch, TurnOff:turn off the relay switch, Toggle:toggle the relay switch state, SetMode:set the mode of the relay switch" required:"true"`
+	Switch  int      `json:"switch" title:"Switch" minimum:"1" maximum:"2" description:"Switch number (1 or 2)" required:"true"`
+	Mode    int      `json:"mode" title:"Mode" minimum:"0" maximum:"3" description:"Mode (0:toggle mode, 1:edge switch mode, 2:detached switch mode, 3:momentary switch mode)"`
+	_       struct{} `additionalProperties:"false"`
+}
+
+// RelaySwitch2PMDeviceCommandSetModeIfExposer represents the SetMode command parameters
+type RelaySwitch2PMDeviceCommandSetModeIfExposer struct{}
+
+// JSONSchemaIf returns the JSON schema if block for the RelaySwitch2PMDevice command parameter for SetMode
+func (parameter *RelaySwitch2PMDeviceCommandSetModeIfExposer) JSONSchemaIf() interface{} {
+	return struct {
+		Command string `json:"command" const:"SetMode" required:"true"`
+	}{}
+}
+
+// JSONSchemaThen returns the JSON schema then block for the RelaySwitch2PMDevice command parameter for SetMode
+func (parameter *RelaySwitch2PMDeviceCommandSetModeIfExposer) JSONSchemaThen() interface{} {
+	return struct {
+		Mode int `json:"mode" required:"true"`
+	}{}
+}
+
+// JSONSchemaAllOf returns the JSON schema allOf block for the RelaySwitch2PMDevice command parameter
+func (parameter *RelaySwitch2PMDeviceCommandParameter) JSONSchemaAllOf() []interface{} {
+	return []interface{}{
+		&RelaySwitch2PMDeviceCommandSetModeIfExposer{},
+	}
+}
+
+// ExecCommand sends a command to the RelaySwitch2PMDevice
+func (device *RelaySwitch2PMDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter RelaySwitch2PMDeviceCommandParameter
+	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
+		return nil, err
+	}
+
+	switch parameter.Command {
+	case "TurnOn":
+		return device.TurnOn(parameter.Switch)
+	case "TurnOff":
+		return device.TurnOff(parameter.Switch)
+	case "Toggle":
+		return device.Toggle(parameter.Switch)
+	case "SetMode":
+		return device.SetMode(parameter.Switch, RelaySwitchMode(parameter.Mode))
+	default:
+		return nil, fmt.Errorf("invalid Command: %s", parameter.Command)
+	}
+}
+
+// GetCommandParameterJSONSchema returns the JSON schema for the RelaySwitch2PMDevice command parameter
+func (device *RelaySwitch2PMDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(RelaySwitch2PMDeviceCommandParameter{})
+}
+
 // InfraredRemoteAirConditionerDeviceCommandParameter is a struct that represents the command parameter for the InfraredRemoteAirConditionerDevice
 type InfraredRemoteAirConditionerDeviceCommandParameter struct {
 	Command            string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,SetAll" description:"TurnOn:turn on the air conditioner, TurnOff:turn off the air conditioner, SetAll:configure all parameters of the air conditioner" required:"true"`

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -163,6 +163,34 @@ func (device *LockDevice) GetCommandParameterJSONSchema() (string, error) {
 	return reflectJSONSchema(LockDeviceCommandParameter{})
 }
 
+// LockLiteDeviceCommandParameter is a struct that represents the command parameter for the LockLiteDevice
+type LockLiteDeviceCommandParameter struct {
+	Command string   `json:"command" title:"Command" enum:"Lock,Unlock" description:"Lock:rotate to locked position, Unlock:rotate to unlocked position" required:"true"`
+	_       struct{} `additionalProperties:"false"`
+}
+
+// ExecCommand sends a command to the LockLiteDevice
+func (device *LockLiteDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter LockLiteDeviceCommandParameter
+	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
+		return nil, err
+	}
+
+	switch parameter.Command {
+	case "Lock":
+		return device.Lock()
+	case "Unlock":
+		return device.Unlock()
+	default:
+		return nil, fmt.Errorf("invalid Command: %s", parameter.Command)
+	}
+}
+
+// GetCommandParameterJSONSchema returns the JSON schema for the LockLiteDevice command parameter
+func (device *LockLiteDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(LockLiteDeviceCommandParameter{})
+}
+
 // KeypadDeviceCommandParameter is a struct that represents the command parameter for the KeypadDevice
 type KeypadDeviceCommandParameter struct {
 	Command   string   `json:"command" title:"Command" enum:"CreateKey,DeleteKey" required:"true" description:"CreateKey:create a new passcode, DeleteKey:delete an existing passcode"`

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -1575,6 +1575,34 @@ func (device *GarageDoorOpenerDevice) GetCommandParameterJSONSchema() (string, e
 	return reflectJSONSchema(GarageDoorOpenerDeviceCommandParameter{})
 }
 
+// VideoDoorbellDeviceCommandParameter is a struct that represents the command parameter for the VideoDoorbellDevice
+type VideoDoorbellDeviceCommandParameter struct {
+	Command string   `json:"command" title:"Command" enum:"EnableMotionDetection,DisableMotionDetection" description:"EnableMotionDetection:enable motion detection, DisableMotionDetection:disable motion detection" required:"true"`
+	_       struct{} `additionalProperties:"false"`
+}
+
+// ExecCommand sends a command to the VideoDoorbellDevice
+func (device *VideoDoorbellDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter VideoDoorbellDeviceCommandParameter
+	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
+		return nil, err
+	}
+
+	switch parameter.Command {
+	case "EnableMotionDetection":
+		return device.EnableMotionDetection()
+	case "DisableMotionDetection":
+		return device.DisableMotionDetection()
+	default:
+		return nil, fmt.Errorf("invalid Command: %s", parameter.Command)
+	}
+}
+
+// GetCommandParameterJSONSchema returns the JSON schema for the VideoDoorbellDevice command parameter
+func (device *VideoDoorbellDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(&VideoDoorbellDeviceCommandParameter{})
+}
+
 // InfraredRemoteAirConditionerDeviceCommandParameter is a struct that represents the command parameter for the InfraredRemoteAirConditionerDevice
 type InfraredRemoteAirConditionerDeviceCommandParameter struct {
 	Command            string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,SetAll" description:"TurnOn:turn on the air conditioner, TurnOff:turn off the air conditioner, SetAll:configure all parameters of the air conditioner" required:"true"`

--- a/device_control_json.go
+++ b/device_control_json.go
@@ -1519,6 +1519,34 @@ func (device *RelaySwitch2PMDevice) GetCommandParameterJSONSchema() (string, err
 	return reflectJSONSchema(RelaySwitch2PMDeviceCommandParameter{})
 }
 
+// GarageDoorOpenerDeviceCommandParameter is a struct that represents the command parameter for the GarageDoorOpenerDevice
+type GarageDoorOpenerDeviceCommandParameter struct {
+	Command string   `json:"command" title:"Command" enum:"TurnOn,TurnOff" description:"TurnOn:open the garage door, TurnOff:close the garage door" required:"true"`
+	_       struct{} `additionalProperties:"false"`
+}
+
+// ExecCommand sends a command to the GarageDoorOpenerDevice
+func (device *GarageDoorOpenerDevice) ExecCommand(jsonString string) (*CommonResponse, error) {
+	var parameter GarageDoorOpenerDeviceCommandParameter
+	if err := validateAndUnmarshalJSON(device, jsonString, &parameter); err != nil {
+		return nil, err
+	}
+
+	switch parameter.Command {
+	case "TurnOn":
+		return device.TurnOn()
+	case "TurnOff":
+		return device.TurnOff()
+	default:
+		return nil, fmt.Errorf("invalid Command: %s", parameter.Command)
+	}
+}
+
+// GetCommandParameterJSONSchema returns the JSON schema for the GarageDoorOpenerDevice command parameter
+func (device *GarageDoorOpenerDevice) GetCommandParameterJSONSchema() (string, error) {
+	return reflectJSONSchema(GarageDoorOpenerDeviceCommandParameter{})
+}
+
 // InfraredRemoteAirConditionerDeviceCommandParameter is a struct that represents the command parameter for the InfraredRemoteAirConditionerDevice
 type InfraredRemoteAirConditionerDeviceCommandParameter struct {
 	Command            string   `json:"command" title:"Command" enum:"TurnOn,TurnOff,SetAll" description:"TurnOn:turn on the air conditioner, TurnOff:turn off the air conditioner, SetAll:configure all parameters of the air conditioner" required:"true"`

--- a/device_control_json_test.go
+++ b/device_control_json_test.go
@@ -1057,15 +1057,15 @@ func Test_RobotVacuumCleanerDeviceExecCommandInvalid(t *testing.T) {
 	}
 }
 
-func Test_RobotVacuumCleanerS10DeviceGetCommandParameterJSONSchema(t *testing.T) {
-	device := &switchbot.RobotVacuumCleanerS10Device{}
+func Test_RobotVacuumCleanerSDeviceGetCommandParameterJSONSchema(t *testing.T) {
+	device := &switchbot.RobotVacuumCleanerSDevice{}
 
 	description, err := device.GetCommandParameterJSONSchema()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, description)
 }
 
-func Test_RobotVacuumCleanerS10DeviceExecCommand(t *testing.T) {
+func Test_RobotVacuumCleanerSDeviceExecCommand(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		expectedBody string
@@ -1116,7 +1116,7 @@ func Test_RobotVacuumCleanerS10DeviceExecCommand(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.RobotVacuumCleanerS10Device{
+			device := &switchbot.RobotVacuumCleanerSDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",
@@ -1133,7 +1133,7 @@ func Test_RobotVacuumCleanerS10DeviceExecCommand(t *testing.T) {
 	}
 }
 
-func Test_RobotVacuumCleanerS10DeviceExecCommandInvalid(t *testing.T) {
+func Test_RobotVacuumCleanerSDeviceExecCommandInvalid(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		parameter    string
@@ -1228,7 +1228,7 @@ func Test_RobotVacuumCleanerS10DeviceExecCommandInvalid(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.RobotVacuumCleanerS10Device{
+			device := &switchbot.RobotVacuumCleanerSDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",

--- a/device_control_json_test.go
+++ b/device_control_json_test.go
@@ -784,14 +784,14 @@ func Test_StripLightDeviceExecCommandInvalid(t *testing.T) {
 	}
 }
 
-func Test_ColorBulbDeviceGetCommandParameterJSONSchema(t *testing.T) {
-	device := &switchbot.ColorBulbDevice{}
+func Test_ColorLightDeviceGetCommandParameterJSONSchema(t *testing.T) {
+	device := &switchbot.ColorLightDevice{}
 	schema, err := device.GetCommandParameterJSONSchema()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schema)
 }
 
-func Test_ColorBulbDeviceExecCommand(t *testing.T) {
+func Test_ColorLightDeviceExecCommand(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		expectedBody string
@@ -837,7 +837,7 @@ func Test_ColorBulbDeviceExecCommand(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.ColorBulbDevice{
+			device := &switchbot.ColorLightDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",
@@ -854,7 +854,7 @@ func Test_ColorBulbDeviceExecCommand(t *testing.T) {
 	}
 }
 
-func Test_ColorBulbDeviceExecCommandInvalid(t *testing.T) {
+func Test_ColorLightDeviceExecCommandInvalid(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		parameter    string
@@ -934,7 +934,7 @@ func Test_ColorBulbDeviceExecCommandInvalid(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.ColorBulbDevice{
+			device := &switchbot.ColorLightDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",

--- a/device_control_test.go
+++ b/device_control_test.go
@@ -412,16 +412,16 @@ func TestRobotVacuumCleanerDevice(t *testing.T) {
 	}
 }
 
-func TestRobotVacuumCleanerS10Device(t *testing.T) {
+func TestRobotVacuumCleanerSDevice(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		expectedBody string
-		method       func(*switchbot.RobotVacuumCleanerS10Device) (*switchbot.CommonResponse, error)
+		method       func(*switchbot.RobotVacuumCleanerSDevice) (*switchbot.CommonResponse, error)
 	}{
 		{
 			name:         "StartClean",
 			expectedBody: `{"commandType":"command","command":"startClean","parameter":{"action":"sweep","param":{"fanLevel":1,"waterLevel":2,"times":100}}}`,
-			method: func(device *switchbot.RobotVacuumCleanerS10Device) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.RobotVacuumCleanerSDevice) (*switchbot.CommonResponse, error) {
 				startFloorCleaningParam, err := switchbot.NewStartFloorCleaningParam(switchbot.FloorCleaningActionSweep, 1, 2, 100)
 				if err != nil {
 					return nil, err
@@ -432,21 +432,21 @@ func TestRobotVacuumCleanerS10Device(t *testing.T) {
 		{
 			name:         "SetVolume",
 			expectedBody: `{"commandType":"command","command":"setVolume","parameter":"30"}`,
-			method: func(device *switchbot.RobotVacuumCleanerS10Device) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.RobotVacuumCleanerSDevice) (*switchbot.CommonResponse, error) {
 				return device.SetVolume(30)
 			},
 		},
 		{
 			name:         "SelfClean",
 			expectedBody: `{"commandType":"command","command":"selfClean","parameter":"1"}`,
-			method: func(device *switchbot.RobotVacuumCleanerS10Device) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.RobotVacuumCleanerSDevice) (*switchbot.CommonResponse, error) {
 				return device.SelfClean(switchbot.WashMopSelfCleaningMode)
 			},
 		},
 		{
 			name:         "ChangeParam",
 			expectedBody: `{"commandType":"command","command":"changeParam","parameter":{"fanLevel":2,"waterLevel":1,"times":20000}}`,
-			method: func(device *switchbot.RobotVacuumCleanerS10Device) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.RobotVacuumCleanerSDevice) (*switchbot.CommonResponse, error) {
 				floorCleaningParam, err := switchbot.NewFloorCleaningParam(2, 1, 20000)
 				if err != nil {
 					return nil, err
@@ -464,7 +464,7 @@ func TestRobotVacuumCleanerS10Device(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.RobotVacuumCleanerS10Device{
+			device := &switchbot.RobotVacuumCleanerSDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",

--- a/device_control_test.go
+++ b/device_control_test.go
@@ -321,30 +321,30 @@ func TestStripLightDevice(t *testing.T) {
 	}
 }
 
-func TestColorBulbDevice(t *testing.T) {
+func TestColorLightDevice(t *testing.T) {
 	testDataList := []struct {
 		name         string
 		expectedBody string
-		method       func(*switchbot.ColorBulbDevice) (*switchbot.CommonResponse, error)
+		method       func(*switchbot.ColorLightDevice) (*switchbot.CommonResponse, error)
 	}{
 		{
 			name:         "SetBrightness",
 			expectedBody: `{"commandType": "command","command": "setBrightness","parameter": "55"}`,
-			method: func(device *switchbot.ColorBulbDevice) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.ColorLightDevice) (*switchbot.CommonResponse, error) {
 				return device.SetBrightness(55)
 			},
 		},
 		{
 			name:         "SetColor",
 			expectedBody: `{"commandType": "command","command": "setColor","parameter": "255:100:0"}`,
-			method: func(device *switchbot.ColorBulbDevice) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.ColorLightDevice) (*switchbot.CommonResponse, error) {
 				return device.SetColor(color.RGBA{R: 255, G: 100, B: 0, A: 0})
 			},
 		},
 		{
 			name:         "SetColorTemperature",
 			expectedBody: `{"commandType": "command","command": "setColorTemperature","parameter": "5000"}`,
-			method: func(device *switchbot.ColorBulbDevice) (*switchbot.CommonResponse, error) {
+			method: func(device *switchbot.ColorLightDevice) (*switchbot.CommonResponse, error) {
 				return device.SetColorTemperature(5000)
 			},
 		},
@@ -358,7 +358,7 @@ func TestColorBulbDevice(t *testing.T) {
 			defer testServer.Close()
 
 			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
-			device := &switchbot.ColorBulbDevice{
+			device := &switchbot.ColorLightDevice{
 				CommonDeviceListItem: switchbot.CommonDeviceListItem{
 					CommonDevice: switchbot.CommonDevice{
 						DeviceID: "ABCDEF123456",

--- a/device_control_test.go
+++ b/device_control_test.go
@@ -1179,6 +1179,52 @@ func TestGarageDoorOpenerDevice(t *testing.T) {
 		})
 	}
 }
+func TestVideoDoorbellDevice(t *testing.T) {
+	testDataList := []struct {
+		name         string
+		expectedBody string
+		method       func(*switchbot.VideoDoorbellDevice) (*switchbot.CommonResponse, error)
+	}{
+		{
+			name:         "EnableMotionDetection",
+			expectedBody: `{"commandType": "command","command": "enableMotionDetection","parameter": "default"}`,
+			method: func(device *switchbot.VideoDoorbellDevice) (*switchbot.CommonResponse, error) {
+				return device.EnableMotionDetection()
+			},
+		},
+		{
+			name:         "DisableMotionDetection",
+			expectedBody: `{"commandType": "command","command": "disableMotionDetection","parameter": "default"}`,
+			method: func(device *switchbot.VideoDoorbellDevice) (*switchbot.CommonResponse, error) {
+				return device.DisableMotionDetection()
+			},
+		},
+	}
+
+	for _, testData := range testDataList {
+		t.Run(testData.name, func(t *testing.T) {
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
+			defer testServer.Close()
+
+			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+			device := &switchbot.VideoDoorbellDevice{
+				CommonDeviceListItem: switchbot.CommonDeviceListItem{
+					CommonDevice: switchbot.CommonDevice{
+						DeviceID: "ABCDEF123456",
+					},
+					Client: client,
+				},
+			}
+
+			_, err := testData.method(device)
+			assert.NoError(t, err)
+
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
+		})
+	}
+}
 
 func TestInfraredRemoteAirConditionerDevice(t *testing.T) {
 	testDataList := []struct {

--- a/device_control_test.go
+++ b/device_control_test.go
@@ -996,6 +996,101 @@ func TestRelaySwitch1Device(t *testing.T) {
 	}
 }
 
+func TestRelaySwitch2PMDevice(t *testing.T) {
+	testDataList := []struct {
+		name         string
+		expectedBody string
+		method       func(*switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error)
+	}{
+		{
+			name:         "TurnOn switch 1",
+			expectedBody: `{"commandType": "command","command": "turnOn","parameter": "1"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.TurnOn(1)
+			},
+		},
+		{
+			name:         "TurnOn switch 2",
+			expectedBody: `{"commandType": "command","command": "turnOn","parameter": "2"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.TurnOn(2)
+			},
+		},
+		{
+			name:         "TurnOff switch 1",
+			expectedBody: `{"commandType": "command","command": "turnOff","parameter": "1"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.TurnOff(1)
+			},
+		},
+		{
+			name:         "TurnOff switch 2",
+			expectedBody: `{"commandType": "command","command": "turnOff","parameter": "2"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.TurnOff(2)
+			},
+		},
+		{
+			name:         "Toggle switch 1",
+			expectedBody: `{"commandType": "command","command": "toggle","parameter": "1"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.Toggle(1)
+			},
+		},
+		{
+			name:         "Toggle switch 2",
+			expectedBody: `{"commandType": "command","command": "toggle","parameter": "2"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.Toggle(2)
+			},
+		},
+		{
+			name:         "SetMode(Toggle) switch 1",
+			expectedBody: `{"commandType": "command","command": "setMode","parameter": "1,0"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.SetMode(1, switchbot.RelaySwitchModeToggle)
+			},
+		},
+		{
+			name:         "SetMode(Momentary) switch 1",
+			expectedBody: `{"commandType": "command","command": "setMode","parameter": "1,3"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.SetMode(1, switchbot.RelaySwitchModeMomentary)
+			},
+		},
+		{
+			name:         "SetMode(Detached) switch 2",
+			expectedBody: `{"commandType": "command","command": "setMode","parameter": "2,2"}`,
+			method: func(device *switchbot.RelaySwitch2PMDevice) (*switchbot.CommonResponse, error) {
+				return device.SetMode(2, switchbot.RelaySwitchModeDetached)
+			},
+		},
+	}
+
+	for _, testData := range testDataList {
+		t.Run(testData.name, func(t *testing.T) {
+			switchBotMock := helpers.NewSwitchBotMock(t)
+			switchBotMock.RegisterCommandMock("ABCDEF123456", testData.expectedBody)
+			testServer := switchBotMock.NewTestServer()
+			defer testServer.Close()
+
+			client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+			device := &switchbot.RelaySwitch2PMDevice{
+				CommonDeviceListItem: switchbot.CommonDeviceListItem{
+					CommonDevice: switchbot.CommonDevice{
+						DeviceID: "ABCDEF123456",
+					},
+					Client: client,
+				},
+			}
+			response, err := testData.method(device)
+			assert.NoError(t, err)
+			assertResponse(t, response)
+			switchBotMock.AssertCallCount(http.MethodPost, "/devices/ABCDEF123456/commands", 1)
+		})
+	}
+}
+
 func TestInfraredRemoteAirConditionerDevice(t *testing.T) {
 	testDataList := []struct {
 		name         string

--- a/device_status.go
+++ b/device_status.go
@@ -992,6 +992,39 @@ func (device *RelaySwitch2PMDevice) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
+// VideoDoorbellDeviceStatusBody represents the status body of a Video Doorbell device
+type VideoDoorbellDeviceStatusBody struct {
+	CommonDevice
+	Online  bool   `json:"online"`
+	Battery int    `json:"battery"`
+	Version string `json:"version"`
+}
+
+// VideoDoorbellDeviceStatusResponse represents the status response for a Video Doorbell device
+type VideoDoorbellDeviceStatusResponse struct {
+	CommonResponse
+	Body *VideoDoorbellDeviceStatusBody `json:"body"`
+}
+
+// GetStatus retrieves the current status of the VideoDoorbellDevice
+func (device *VideoDoorbellDevice) GetStatus() (*VideoDoorbellDeviceStatusResponse, error) {
+	response := &VideoDoorbellDeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *VideoDoorbellDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 // GarageDoorOpenerDeviceStatusBody represents the status of a Garage Door Opener device
 type GarageDoorOpenerDeviceStatusBody struct {
 	CommonDevice

--- a/device_status.go
+++ b/device_status.go
@@ -960,3 +960,36 @@ func (device *RelaySwitch2PMDevice) GetAnyStatusBody() (any, error) {
 	}
 	return status.Body, nil
 }
+
+// GarageDoorOpenerDeviceStatusBody represents the status of a Garage Door Opener device
+type GarageDoorOpenerDeviceStatusBody struct {
+	CommonDevice
+	DoorStatus int    `json:"doorStatus"`
+	Online     bool   `json:"online"`
+	Version    string `json:"version"`
+}
+
+// GarageDoorOpenerDeviceStatusResponse represents the response from getting the status of a Garage Door Opener device
+type GarageDoorOpenerDeviceStatusResponse struct {
+	CommonResponse
+	Body *GarageDoorOpenerDeviceStatusBody `json:"body"`
+}
+
+// GetStatus retrieves the current status of the GarageDoorOpenerDevice
+func (device *GarageDoorOpenerDevice) GetStatus() (*GarageDoorOpenerDeviceStatusResponse, error) {
+	response := &GarageDoorOpenerDeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *GarageDoorOpenerDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}

--- a/device_status.go
+++ b/device_status.go
@@ -486,7 +486,7 @@ func (device *StripLightDevice) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
-type ColorBulbDeviceStatusBody struct {
+type ColorLightDeviceStatusBody struct {
 	CommonDevice
 	Power            string `json:"power"`
 	Brightness       int    `json:"brightness"`
@@ -495,13 +495,13 @@ type ColorBulbDeviceStatusBody struct {
 	ColorTemperature int    `json:"colorTemperature"`
 }
 
-type ColorBulbDeviceStatusResponse struct {
+type ColorLightDeviceStatusResponse struct {
 	CommonResponse
-	Body *ColorBulbDeviceStatusBody `json:"body"`
+	Body *ColorLightDeviceStatusBody `json:"body"`
 }
 
-func (device *ColorBulbDevice) GetStatus() (*ColorBulbDeviceStatusResponse, error) {
-	response := &ColorBulbDeviceStatusResponse{}
+func (device *ColorLightDevice) GetStatus() (*ColorLightDeviceStatusResponse, error) {
+	response := &ColorLightDeviceStatusResponse{}
 	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
 	if err != nil {
 		return nil, err
@@ -510,7 +510,7 @@ func (device *ColorBulbDevice) GetStatus() (*ColorBulbDeviceStatusResponse, erro
 }
 
 // GetAnyStatusBody returns the status of the device as a value of type `any`
-func (device *ColorBulbDevice) GetAnyStatusBody() (any, error) {
+func (device *ColorLightDevice) GetAnyStatusBody() (any, error) {
 	status, err := device.GetStatus()
 	if err != nil {
 		return nil, err

--- a/device_status.go
+++ b/device_status.go
@@ -548,7 +548,7 @@ func (device *RobotVacuumCleanerDevice) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
-type RobotVacuumCleanerS10DeviceStatusBody struct {
+type RobotVacuumCleanerSDeviceStatusBody struct {
 	CommonDevice
 	WorkingStatus    string `json:"workingStatus"`
 	OnlineStatus     string `json:"onlineStatus"`
@@ -557,13 +557,13 @@ type RobotVacuumCleanerS10DeviceStatusBody struct {
 	TaskType         string `json:"taskType"`
 }
 
-type RobotVacuumCleanerS10DeviceStatusResponse struct {
+type RobotVacuumCleanerSDeviceStatusResponse struct {
 	CommonResponse
-	Body *RobotVacuumCleanerS10DeviceStatusBody `json:"body"`
+	Body *RobotVacuumCleanerSDeviceStatusBody `json:"body"`
 }
 
-func (device *RobotVacuumCleanerS10Device) GetStatus() (*RobotVacuumCleanerS10DeviceStatusResponse, error) {
-	response := &RobotVacuumCleanerS10DeviceStatusResponse{}
+func (device *RobotVacuumCleanerSDevice) GetStatus() (*RobotVacuumCleanerSDeviceStatusResponse, error) {
+	response := &RobotVacuumCleanerSDeviceStatusResponse{}
 	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
 	if err != nil {
 		return nil, err
@@ -572,7 +572,7 @@ func (device *RobotVacuumCleanerS10Device) GetStatus() (*RobotVacuumCleanerS10De
 }
 
 // GetAnyStatusBody returns the status of the device as a value of type `any`
-func (device *RobotVacuumCleanerS10Device) GetAnyStatusBody() (any, error) {
+func (device *RobotVacuumCleanerSDevice) GetAnyStatusBody() (any, error) {
 	status, err := device.GetStatus()
 	if err != nil {
 		return nil, err

--- a/device_status.go
+++ b/device_status.go
@@ -580,6 +580,40 @@ func (device *RobotVacuumCleanerSDevice) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
+// RobotVacuumCleanerComboDeviceStatusBody represents the status body of a Robot Vacuum Cleaner Combo device
+type RobotVacuumCleanerComboDeviceStatusBody struct {
+	CommonDevice
+	WorkingStatus string `json:"workingStatus"`
+	OnlineStatus  string `json:"onlineStatus"`
+	Battery       int    `json:"battery"`
+	TaskType      string `json:"taskType"`
+}
+
+// RobotVacuumCleanerComboDeviceStatusResponse represents the status response for a Robot Vacuum Cleaner Combo device
+type RobotVacuumCleanerComboDeviceStatusResponse struct {
+	CommonResponse
+	Body *RobotVacuumCleanerComboDeviceStatusBody `json:"body"`
+}
+
+// GetStatus retrieves the status of the RobotVacuumCleanerComboDevice
+func (device *RobotVacuumCleanerComboDevice) GetStatus() (*RobotVacuumCleanerComboDeviceStatusResponse, error) {
+	response := &RobotVacuumCleanerComboDeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RobotVacuumCleanerComboDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type HumidifierDeviceStatusBody struct {
 	CommonDevice
 	Power                  string `json:"power"`

--- a/device_status.go
+++ b/device_status.go
@@ -915,3 +915,48 @@ func (device *RelaySwitch1Device) GetAnyStatusBody() (any, error) {
 	}
 	return status.Body, nil
 }
+
+// RelaySwitch2PMDeviceStatusBody represents the status of a Relay Switch 2PM device
+type RelaySwitch2PMDeviceStatusBody struct {
+	CommonDevice
+	Online                 bool   `json:"online"`
+	Switch1Status          int    `json:"switch1Status"`
+	Switch2Status          int    `json:"switch2Status"`
+	Switch1Voltage         int    `json:"switch1voltage"`
+	Switch2Voltage         int    `json:"switch2voltage"`
+	Version                string `json:"version"`
+	Switch1Power           int    `json:"switch1power"`
+	Switch2Power           int    `json:"switch2power"`
+	Switch1UsedElectricity int    `json:"switch1usedElectricity"`
+	Switch2UsedElectricity int    `json:"switch2usedElectricity"`
+	Switch1ElectricCurrent int    `json:"switch1electricCurrent"`
+	Switch2ElectricCurrent int    `json:"switch2electricCurrent"`
+	Calibrate              bool   `json:"calibrate"`
+	Position               int    `json:"position"`
+	IsStuck                string `json:"isStuck"`
+}
+
+// RelaySwitch2PMDeviceStatusResponse represents the response from getting the status of a Relay Switch 2PM device
+type RelaySwitch2PMDeviceStatusResponse struct {
+	CommonResponse
+	Body *RelaySwitch2PMDeviceStatusBody `json:"body"`
+}
+
+// GetStatus retrieves the current status of the RelaySwitch2PMDevice
+func (device *RelaySwitch2PMDevice) GetStatus() (*RelaySwitch2PMDeviceStatusResponse, error) {
+	response := &RelaySwitch2PMDeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *RelaySwitch2PMDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}

--- a/device_status.go
+++ b/device_status.go
@@ -114,6 +114,39 @@ func (device *Hub2Device) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
+type Hub3DeviceStatusBody struct {
+	CommonDevice
+	Temperature  float64 `json:"temperature"`
+	LightLevel   int     `json:"lightLevel"`
+	Version      string  `json:"version"`
+	Humidity     int     `json:"humidity"`
+	MoveDetected bool    `json:"moveDetected"`
+	Online       string  `json:"online"`
+}
+
+type Hub3DeviceStatusResponse struct {
+	CommonResponse
+	Body *Hub3DeviceStatusBody `json:"body"`
+}
+
+func (device *Hub3Device) GetStatus() (*Hub3DeviceStatusResponse, error) {
+	response := &Hub3DeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *Hub3Device) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type MeterDeviceStatusBody struct {
 	CommonDevice
 	Temperature float64 `json:"temperature"`

--- a/device_status.go
+++ b/device_status.go
@@ -242,6 +242,37 @@ func (device *LockDevice) GetAnyStatusBody() (any, error) {
 	return status.Body, nil
 }
 
+type LockLiteDeviceStatusBody struct {
+	CommonDevice
+	Battery   int    `json:"battery"`
+	Version   string `json:"version"`
+	LockState string `json:"lockState"`
+	Calibrate bool   `json:"calibrate"`
+}
+
+type LockLiteDeviceStatusResponse struct {
+	CommonResponse
+	Body *LockLiteDeviceStatusBody `json:"body"`
+}
+
+func (device *LockLiteDevice) GetStatus() (*LockLiteDeviceStatusResponse, error) {
+	response := &LockLiteDeviceStatusResponse{}
+	err := device.Client.GetRequest("/devices/"+device.DeviceID+"/status", GetDeviceStatusResponseParser(response))
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetAnyStatusBody returns the status of the device as a value of type `any`
+func (device *LockLiteDevice) GetAnyStatusBody() (any, error) {
+	status, err := device.GetStatus()
+	if err != nil {
+		return nil, err
+	}
+	return status.Body, nil
+}
+
 type KeypadDeviceStatusBody struct {
 	CommonDevice
 }

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -865,7 +865,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		assertBody(t, anyStatus, expectedBody)
 	})
 
-	t.Run("RobotVacuumCleanerS10Device", func(t *testing.T) {
+	t.Run("RobotVacuumCleanerSDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
 		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
 			"deviceId":         "ABCDEF123456",
@@ -882,7 +882,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
 
-		device := &switchbot.RobotVacuumCleanerS10Device{
+		device := &switchbot.RobotVacuumCleanerSDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
 					DeviceID: "ABCDEF123456",
@@ -895,7 +895,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 
 		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
-		expectedBody := &switchbot.RobotVacuumCleanerS10DeviceStatusBody{
+		expectedBody := &switchbot.RobotVacuumCleanerSDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
 				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Robot Vacuum Cleaner S10",

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -765,7 +765,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		assertBody(t, anyStatus, expectedBody)
 	})
 
-	t.Run("ColorBulbDevice", func(t *testing.T) {
+	t.Run("ColorLightDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
 		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
 			"deviceId":         "ABCDEF123456",
@@ -782,7 +782,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 
 		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
 
-		device := &switchbot.ColorBulbDevice{
+		device := &switchbot.ColorLightDevice{
 			CommonDeviceListItem: switchbot.CommonDeviceListItem{
 				CommonDevice: switchbot.CommonDevice{
 					DeviceID: "ABCDEF123456",
@@ -795,7 +795,7 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 
 		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
 
-		expectedBody := &switchbot.ColorBulbDeviceStatusBody{
+		expectedBody := &switchbot.ColorLightDeviceStatusBody{
 			CommonDevice: switchbot.CommonDevice{
 				DeviceID:    "ABCDEF123456",
 				DeviceType:  "Color Bulb",

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -1668,7 +1668,8 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			Version: "1.0",
 		}
 
-		assert.Equal(t, expectedBody, status.Body)
+		assertResponse(t, &status.CommonResponse)
+		assertBody(t, status.Body, expectedBody)
 
 		// Test GetAnyStatusBody
 		anyStatus, err := device.GetAnyStatusBody()

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -165,6 +165,60 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		assertBody(t, anyStatus, expectedBody)
 	})
 
+	t.Run("Hub3Device", func(t *testing.T) {
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":     "ABCDEF123456",
+			"deviceType":   "Hub 3",
+			"hubDeviceId":  "123456789",
+			"temperature":  23.5,
+			"lightLevel":   400,
+			"version":      "1.3",
+			"humidity":     65,
+			"moveDetected": true,
+			"online":       "online",
+		})
+		testServer := switchBotMock.NewTestServer()
+		defer testServer.Close()
+
+		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+
+		device := &switchbot.Hub3Device{
+			CommonDeviceListItem: switchbot.CommonDeviceListItem{
+				CommonDevice: switchbot.CommonDevice{
+					DeviceID: "ABCDEF123456",
+				},
+				Client: client,
+			},
+		}
+		status, err := device.GetStatus()
+		assert.NoError(t, err)
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
+
+		expectedBody := &switchbot.Hub3DeviceStatusBody{
+			CommonDevice: switchbot.CommonDevice{
+				DeviceID:    "ABCDEF123456",
+				DeviceType:  "Hub 3",
+				HubDeviceId: "123456789",
+			},
+			Temperature:  23.5,
+			LightLevel:   400,
+			Version:      "1.3",
+			Humidity:     65,
+			MoveDetected: true,
+			Online:       "online",
+		}
+
+		assertResponse(t, &status.CommonResponse)
+		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		assert.NoError(t, err)
+		assertBody(t, anyStatus, expectedBody)
+	})
+
 	t.Run("MeterDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
 		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -1457,6 +1457,78 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		assert.NoError(t, err)
 		assertBody(t, anyStatus, expectedBody)
 	})
+
+	t.Run("RelaySwitch2PMDevice", func(t *testing.T) {
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":               "ABCDEF123456",
+			"deviceType":             "Relay Switch 2PM",
+			"hubDeviceId":            "123456789",
+			"online":                 true,
+			"switch1Status":          1,
+			"switch2Status":          0,
+			"switch1voltage":         120,
+			"switch2voltage":         0,
+			"version":                "V3.1-6.3",
+			"switch1power":           50,
+			"switch2power":           0,
+			"switch1usedElectricity": 1000,
+			"switch2usedElectricity": 0,
+			"switch1electricCurrent": 500,
+			"switch2electricCurrent": 0,
+			"calibrate":              true,
+			"position":               50,
+			"isStuck":                "false",
+		})
+		testServer := switchBotMock.NewTestServer()
+		defer testServer.Close()
+
+		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+
+		device := &switchbot.RelaySwitch2PMDevice{
+			CommonDeviceListItem: switchbot.CommonDeviceListItem{
+				CommonDevice: switchbot.CommonDevice{
+					DeviceID: "ABCDEF123456",
+				},
+				Client: client,
+			},
+		}
+		status, err := device.GetStatus()
+		assert.NoError(t, err)
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
+
+		expectedBody := &switchbot.RelaySwitch2PMDeviceStatusBody{
+			CommonDevice: switchbot.CommonDevice{
+				DeviceID:    "ABCDEF123456",
+				DeviceType:  "Relay Switch 2PM",
+				HubDeviceId: "123456789",
+			},
+			Online:                 true,
+			Switch1Status:          1,
+			Switch2Status:          0,
+			Switch1Voltage:         120,
+			Switch2Voltage:         0,
+			Version:                "V3.1-6.3",
+			Switch1Power:           50,
+			Switch2Power:           0,
+			Switch1UsedElectricity: 1000,
+			Switch2UsedElectricity: 0,
+			Switch1ElectricCurrent: 500,
+			Switch2ElectricCurrent: 0,
+			Calibrate:              true,
+			Position:               50,
+			IsStuck:                "false",
+		}
+
+		assertResponse(t, &status.CommonResponse)
+		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		assert.NoError(t, err)
+		assertBody(t, anyStatus, expectedBody)
+	})
 }
 
 func assertResponse(t *testing.T, response *switchbot.CommonResponse) {

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -373,6 +373,56 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 		assertBody(t, anyStatus, expectedBody)
 	})
 
+	t.Run("LockLiteDevice", func(t *testing.T) {
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":    "ABCDEF123456",
+			"deviceType":  "Smart Lock Lite",
+			"hubDeviceId": "123456789",
+			"battery":     70,
+			"version":     "1.5",
+			"lockState":   "locked",
+			"calibrate":   true,
+		})
+		testServer := switchBotMock.NewTestServer()
+		defer testServer.Close()
+
+		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+
+		device := &switchbot.LockLiteDevice{
+			CommonDeviceListItem: switchbot.CommonDeviceListItem{
+				CommonDevice: switchbot.CommonDevice{
+					DeviceID: "ABCDEF123456",
+				},
+				Client: client,
+			},
+		}
+		status, err := device.GetStatus()
+		assert.NoError(t, err)
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices/ABCDEF123456/status", 1)
+
+		expectedBody := &switchbot.LockLiteDeviceStatusBody{
+			CommonDevice: switchbot.CommonDevice{
+				DeviceID:    "ABCDEF123456",
+				DeviceType:  "Smart Lock Lite",
+				HubDeviceId: "123456789",
+			},
+			Battery:   70,
+			Version:   "1.5",
+			LockState: "locked",
+			Calibrate: true,
+		}
+
+		assertResponse(t, &status.CommonResponse)
+		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		assert.NoError(t, err)
+		assertBody(t, anyStatus, expectedBody)
+	})
+
 	t.Run("KeypadDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
 		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{

--- a/device_status_test.go
+++ b/device_status_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/yasu89/switch-bot-api-go"
+	switchbot "github.com/yasu89/switch-bot-api-go"
 	"github.com/yasu89/switch-bot-api-go/helpers"
 )
 
@@ -906,6 +906,55 @@ func TestGetStatusAndGetAnyStatusBody(t *testing.T) {
 			Battery:          50,
 			WaterBaseBattery: 80,
 			TaskType:         "mop",
+		}
+
+		assertResponse(t, &status.CommonResponse)
+		assertBody(t, status.Body, expectedBody)
+
+		// Test GetAnyStatusBody() method
+		anyStatus, err := device.GetAnyStatusBody()
+		assert.NoError(t, err)
+		assertBody(t, anyStatus, expectedBody)
+	})
+
+	t.Run("RobotVacuumCleanerComboDevice", func(t *testing.T) {
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterStatusMock("ABCDEF123456", map[string]interface{}{
+			"deviceId":      "ABCDEF123456",
+			"deviceType":    "Robot Vacuum Cleaner K10+ Pro Combo",
+			"hubDeviceId":   "123456789",
+			"workingStatus": "Clearing",
+			"onlineStatus":  "online",
+			"battery":       80,
+			"taskType":      "backToCharge",
+		})
+		testServer := switchBotMock.NewTestServer()
+		defer testServer.Close()
+
+		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+
+		device := &switchbot.RobotVacuumCleanerComboDevice{
+			CommonDeviceListItem: switchbot.CommonDeviceListItem{
+				CommonDevice: switchbot.CommonDevice{
+					DeviceID: "ABCDEF123456",
+				},
+				Client: client,
+			},
+		}
+
+		status, err := device.GetStatus()
+		assert.NoError(t, err)
+
+		expectedBody := &switchbot.RobotVacuumCleanerComboDeviceStatusBody{
+			CommonDevice: switchbot.CommonDevice{
+				DeviceID:    "ABCDEF123456",
+				DeviceType:  "Robot Vacuum Cleaner K10+ Pro Combo",
+				HubDeviceId: "123456789",
+			},
+			WorkingStatus: "Clearing",
+			OnlineStatus:  "online",
+			Battery:       80,
+			TaskType:      "backToCharge",
 		}
 
 		assertResponse(t, &status.CommonResponse)

--- a/device_test.go
+++ b/device_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/yasu89/switch-bot-api-go"
+	switchbot "github.com/yasu89/switch-bot-api-go"
 	"github.com/yasu89/switch-bot-api-go/helpers"
 )
 

--- a/device_test.go
+++ b/device_test.go
@@ -152,6 +152,54 @@ func TestGetPhysicalDevices(t *testing.T) {
 		})
 	})
 
+	t.Run("LockLiteDevice", func(t *testing.T) {
+		switchBotMock := helpers.NewSwitchBotMock(t)
+		switchBotMock.RegisterDevicesMock(
+			[]interface{}{
+				map[string]interface{}{
+					"deviceId":           "ABCDEF123456",
+					"deviceType":         "Smart Lock Lite",
+					"hubDeviceId":        "123456789",
+					"deviceName":         "LockLiteDevice",
+					"enableCloudService": true,
+					"group":              true,
+					"master":             false,
+					"groupName":          "LockLiteGroup",
+					"lockDevicesIds":     []string{"BBBBBBBB"},
+				},
+			},
+			[]interface{}{},
+		)
+		testServer := switchBotMock.NewTestServer()
+		defer testServer.Close()
+
+		client := switchbot.NewClient("secret", "token", switchbot.OptionBaseApiURL(testServer.URL))
+
+		response, err := client.GetDevices()
+		assert.NoError(t, err)
+
+		switchBotMock.AssertCallCount(http.MethodGet, "/devices", 1)
+
+		assertDevices(t, response, []interface{}{
+			&switchbot.LockLiteDevice{
+				CommonDeviceListItem: switchbot.CommonDeviceListItem{
+					CommonDevice: switchbot.CommonDevice{
+						DeviceID:    "ABCDEF123456",
+						DeviceType:  "Smart Lock Lite",
+						HubDeviceId: "123456789",
+					},
+					Client:             client,
+					DeviceName:         "LockLiteDevice",
+					EnableCloudService: true,
+				},
+				Group:          true,
+				Master:         false,
+				GroupName:      "LockLiteGroup",
+				LockDevicesIds: []string{"BBBBBBBB"},
+			},
+		})
+	})
+
 	t.Run("KeypadDevice", func(t *testing.T) {
 		switchBotMock := helpers.NewSwitchBotMock(t)
 		switchBotMock.RegisterDevicesMock(


### PR DESCRIPTION
This pull request introduces significant updates to the SwitchBot API Go library, including support for new devices, enhanced type safety, and improved device struct handling. The most important changes are grouped into two themes: **Device Support Expansion** and **Code Refactoring for Device Structs and Commands**.

### Device Support Expansion

* Added support for new devices, including `Hub 3`, `Lock Ultra`, `Floor Cleaning Robot S20`, `Multitasking Household Robot K20+ Pro`, `Relay Switch 2PM`, `Garage Door Opener`, `Floor Lamp`, `LED Strip Light 3`, `Lock Lite`, `Video Doorbell`, and `Keypad Vision`. This includes updates to both `README.md` and `README_ja.md` to reflect the support status. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R84) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R107) [[4]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L54-R62) [[5]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L82-R83) [[6]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L100-R106)

* Enhanced `GetDevicesResponseParser` to dynamically parse responses for the newly supported devices, ensuring type-safe handling of device-specific operations. [[1]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R351-R366) [[2]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4L356-R404) [[3]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R438-R443)

### Code Refactoring for Device Structs and Commands

* Introduced new structs for devices such as `Hub3Device`, `LockLiteDevice`, `ColorLightDevice`, `RobotVacuumCleanerSDevice`, and others, replacing or supplementing existing implementations for better type safety and shared functionality. For example, `ColorBulbDevice` was replaced with `ColorLightDevice` and `RobotVacuumCleanerS10Device` was replaced with `RobotVacuumCleanerSDevice`. [[1]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R60-R63) [[2]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R80-R87) [[3]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4L124-R148) [[4]](diffhunk://#diff-14271c87af5568921ff5c49b376f4d9b0233c11ab49660ec5f6bfd0a1f7174c4R208-R222)

* Updated device-specific command methods to align with the new structs, including methods for locking/unlocking (`LockLiteDevice`), controlling light settings (`ColorLightDevice`), and starting cleaning operations (`RobotVacuumCleanerSDevice`). [[1]](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7R97-R106) [[2]](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7L263-R289) [[3]](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7L291-R302) [[4]](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7L301-R312) [[5]](diffhunk://#diff-f341a110c9c790b2f147f305fac3f828f35a936de8d83a3d46428ccab37768f7L403-R414)

These changes improve the library's compliance with the official SwitchBot API documentation, enhance type safety, and expand support for a broader range of devices.